### PR TITLE
Add a new consumer with error handler for errors reading messages

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
@@ -61,6 +61,13 @@ public interface RabbitMQClient {
   void basicConsume(String queue, String address, boolean autoAck, Handler<AsyncResult<Void>> resultHandler);
 
   /**
+   * Start a non-nolocal, non-exclusive consumer, with a server-generated consumerTag and error handler
+   *
+   * @see com.rabbitmq.client.Channel#basicConsume(String, boolean, String, Consumer)
+   */
+  void basicConsume(String queue, String address, boolean autoAck, Handler<AsyncResult<Void>> resultHandler, Handler<Throwable> errorHandler);
+
+  /**
    * Publish a message. Publishing to a non-existent exchange will result in a channel-level protocol exception,
    * which closes the channel. Invocations of Channel#basicPublish will eventually block if a resource-driven alarm is in effect.
    *

--- a/src/main/java/io/vertx/rabbitmq/impl/ConsumerHandler.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/ConsumerHandler.java
@@ -61,10 +61,8 @@ class ConsumerHandler extends DefaultConsumer {
 
       msg.put("deliveryTag", envelope.getDeliveryTag());
 
-    } catch (UnsupportedEncodingException e) {
-      vertx.runOnContext(v -> {
-        handler.handle(Future.failedFuture(e));
-      });
+    } catch (Exception e) {
+      vertx.runOnContext(v -> handler.handle(Future.failedFuture(e)));
     }
   }
 

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQServiceTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQServiceTest.java
@@ -6,6 +6,7 @@ import static io.vertx.test.core.TestUtils.randomInt;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConnectionFactory;
+import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
@@ -144,6 +145,24 @@ public class RabbitMQServiceTest extends VertxTestBase {
   }
 
   @Test
+  public void testBasicConsumeWithErrorHandler() throws Exception {
+    int count = 3;
+    Set<String> messages = createMessages(count);
+    String q = setupQueue(messages, "application/json");
+
+    CountDownLatch latch = new CountDownLatch(count);
+
+    vertx.eventBus().consumer("my.address", msg -> fail("Getting message with malformed json"));
+
+    Handler<Throwable> errorHandler = throwable -> latch.countDown();
+
+    client.basicConsume(q, "my.address", true, onSuccess(v -> {}), errorHandler);
+
+    awaitLatch(latch);
+    testComplete();
+  }
+
+  @Test
   public void testBasicConsumeNoAutoAck() throws Exception {
 
     int count = 3;
@@ -276,14 +295,20 @@ public class RabbitMQServiceTest extends VertxTestBase {
   }
 
   //TODO More tests
-
   private String setupQueue(Set<String> messages) throws Exception {
+    return setupQueue(messages, null);
+  }
+
+  private String setupQueue(Set<String> messages, String contentType) throws Exception {
     String queue = randomAlphaString(10);
     AMQP.Queue.DeclareOk ok = channel.queueDeclare(queue, false, false, true, null);
     assertNotNull(ok.getQueue());
+    AMQP.BasicProperties properties = new AMQP.BasicProperties.Builder()
+      .contentType(contentType).contentEncoding("UTF-8").build();
+
     if (messages != null) {
       for (String msg : messages) {
-        channel.basicPublish("", queue, new AMQP.BasicProperties(), msg.getBytes("UTF-8"));
+        channel.basicPublish("", queue, properties, msg.getBytes("UTF-8"));
       }
     }
     return queue;


### PR DESCRIPTION
Sometimes there is an error parsing input message, for example if json is malformed. I think is a good idea handle that error in the application, because just show error can be improved. I see no much error handlers in the library, maybe is not the style and can be done another way.