### PR TITLE
Support for non-string values when declaring exchange and queue additional config

### DIFF
--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -101,10 +101,10 @@ public class Examples {
     });
   }
 
-  //pass the additional config for the exchange as map, check RabbitMQ documentation for specific config parameters
+  //pass the additional config for the exchange as JSON, check RabbitMQ documentation for specific config parameters
   public void exchangeDeclareWithConfig(RabbitMQClient client) {
 
-    Map<String, String> config = new HashMap<>();
+    JsonObject config = new JsonObject();
 
     config.put("x-dead-letter-exchange", "my.deadletter.exchange");
     config.put("alternate-exchange", "my.alternate.exchange");
@@ -136,6 +136,22 @@ public class Examples {
         consumeResult.cause().printStackTrace();
       }
     });
+  }
+
+  //pass the additional config for the queue as JSON, check RabbitMQ documentation for specific config parameters
+  public void queueDeclareWithConfig(RabbitMQClient client) {
+    JsonObject config = new JsonObject();
+    config.put("x-message-ttl", 10_000L);
+
+    client.queueDeclare("my-queue", true, false, true, config, queueResult -> {
+      if (queueResult.succeeded()) {
+        System.out.println("Queue declared!");
+      } else {
+        System.err.println("Queue failed to be declared!");
+        queueResult.cause().printStackTrace();
+      }
+    });
+
   }
 
 }

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
@@ -132,6 +132,14 @@ public interface RabbitMQClient {
    */
   void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Map<String, String> config, Handler<AsyncResult<Void>> resultHandler);
 
+
+  /**
+   * Declare an exchange with additional parameters such as dead lettering, an alternate exchange or TTL.
+   *
+   * @see com.rabbitmq.client.Channel#exchangeDeclare(String, String, boolean, boolean, Map)
+   */
+  void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, JsonObject config, Handler<AsyncResult<Void>> resultHandler);
+
   /**
    * Delete an exchange, without regard for whether it is in use or not.
    *

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
@@ -130,7 +130,12 @@ public interface RabbitMQClient {
    * Declare an exchange with additional parameters such as dead lettering or an alternate exchnage.
    *
    * @see com.rabbitmq.client.Channel#exchangeDeclare(String, String, boolean, boolean, Map)
+   * @see #exchangeDeclare(String, String, boolean, boolean, JsonObject, Handler)
+   * @deprecated Use {@link #exchangeDeclare(String, String, boolean, boolean, JsonObject, Handler)} instead for
+   * support for more than just String config values
    */
+  @GenIgnore
+  @Deprecated
   void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Map<String, String> config, Handler<AsyncResult<Void>> resultHandler);
 
 
@@ -139,7 +144,6 @@ public interface RabbitMQClient {
    *
    * @see com.rabbitmq.client.Channel#exchangeDeclare(String, String, boolean, boolean, Map)
    */
-  @GenIgnore
   void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, JsonObject config, Handler<AsyncResult<Void>> resultHandler);
 
   /**
@@ -182,7 +186,12 @@ public interface RabbitMQClient {
    * Declare a queue with config options
    *
    * @see com.rabbitmq.client.Channel#queueDeclare(String, boolean, boolean, boolean, java.util.Map)
+   * @see #queueDeclare(String, boolean, boolean, boolean, JsonObject, Handler)
+   * @deprecated See {@link #queueDeclare(String, boolean, boolean, boolean, JsonObject, Handler)} instead for
+   * support for more than just String config values
    */
+  @GenIgnore
+  @Deprecated
   void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, String> config, Handler<AsyncResult<JsonObject>> resultHandler);
 
   /**
@@ -190,7 +199,6 @@ public interface RabbitMQClient {
    *
    * @see com.rabbitmq.client.Channel#queueDeclare(String, boolean, boolean, boolean, java.util.Map)
    */
-  @GenIgnore
   void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, JsonObject config, Handler<AsyncResult<JsonObject>> resultHandler);
 
 

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
@@ -3,6 +3,7 @@ package io.vertx.rabbitmq;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Consumer;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -138,6 +139,7 @@ public interface RabbitMQClient {
    *
    * @see com.rabbitmq.client.Channel#exchangeDeclare(String, String, boolean, boolean, Map)
    */
+  @GenIgnore
   void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, JsonObject config, Handler<AsyncResult<Void>> resultHandler);
 
   /**
@@ -182,6 +184,15 @@ public interface RabbitMQClient {
    * @see com.rabbitmq.client.Channel#queueDeclare(String, boolean, boolean, boolean, java.util.Map)
    */
   void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, String> config, Handler<AsyncResult<JsonObject>> resultHandler);
+
+  /**
+   * Declare a queue with config options
+   *
+   * @see com.rabbitmq.client.Channel#queueDeclare(String, boolean, boolean, boolean, java.util.Map)
+   */
+  @GenIgnore
+  void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, JsonObject config, Handler<AsyncResult<JsonObject>> resultHandler);
+
 
   /**
    * Delete a queue, without regard for whether it is in use or has messages on it

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -333,13 +333,28 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
   @Override
   public void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Handler<AsyncResult<JsonObject>> resultHandler) {
-    queueDeclare(queue, durable, exclusive, autoDelete, null, resultHandler);
+    queueDeclare(queue, durable, exclusive, autoDelete, (Map<String, String>) null, resultHandler);
   }
 
   @Override
   public void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, String> config, Handler<AsyncResult<JsonObject>> resultHandler) {
     forChannel(resultHandler, channel -> {
       AMQP.Queue.DeclareOk result = channel.queueDeclare(queue, durable, exclusive, autoDelete, toArgumentsMap(config));
+      return toJson(result);
+    });
+  }
+
+  @Override
+  public void queueDeclare(
+    String queue,
+    boolean durable,
+    boolean exclusive,
+    boolean autoDelete,
+    JsonObject config,
+    Handler<AsyncResult<JsonObject>> resultHandler
+  ) {
+    forChannel(resultHandler, channel -> {
+      AMQP.Queue.DeclareOk result = channel.queueDeclare(queue, durable, exclusive, autoDelete, new LinkedHashMap<>(config.getMap()));
       return toJson(result);
     });
   }

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -25,6 +25,7 @@ import io.vertx.rabbitmq.RabbitMQClient;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -271,7 +272,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
   @Override
   public void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Handler<AsyncResult<Void>> resultHandler) {
-    exchangeDeclare(exchange, type, durable, autoDelete, null, resultHandler);
+    exchangeDeclare(exchange, type, durable, autoDelete, (Map<String, String>) null, resultHandler);
   }
 
   @Override
@@ -279,6 +280,21 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
                               Handler<AsyncResult<Void>> resultHandler) {
     forChannel(resultHandler, channel -> {
       channel.exchangeDeclare(exchange, type, durable, autoDelete, toArgumentsMap(config));
+      return null;
+    });
+  }
+
+  @Override
+  public void exchangeDeclare(
+    String exchange,
+    String type,
+    boolean durable,
+    boolean autoDelete,
+    JsonObject config,
+    Handler<AsyncResult<Void>> resultHandler
+  ) {
+    forChannel(resultHandler, channel -> {
+      channel.exchangeDeclare(exchange, type, durable, autoDelete, new LinkedHashMap<>(config.getMap()));
       return null;
     });
   }

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
   private static final Logger log = LoggerFactory.getLogger(RabbitMQClientImpl.class);
+  private static final JsonObject emptyConfig = new JsonObject();
 
   private final Vertx vertx;
   private final JsonObject config;
@@ -272,9 +273,10 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
   @Override
   public void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Handler<AsyncResult<Void>> resultHandler) {
-    exchangeDeclare(exchange, type, durable, autoDelete, (Map<String, String>) null, resultHandler);
+    exchangeDeclare(exchange, type, durable, autoDelete, emptyConfig, resultHandler);
   }
 
+  @Deprecated
   @Override
   public void exchangeDeclare(String exchange, String type, boolean durable, boolean autoDelete, Map<String, String> config,
                               Handler<AsyncResult<Void>> resultHandler) {
@@ -333,9 +335,10 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
   @Override
   public void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Handler<AsyncResult<JsonObject>> resultHandler) {
-    queueDeclare(queue, durable, exclusive, autoDelete, (Map<String, String>) null, resultHandler);
+    queueDeclare(queue, durable, exclusive, autoDelete, emptyConfig, resultHandler);
   }
 
+  @Deprecated
   @Override
   public void queueDeclare(String queue, boolean durable, boolean exclusive, boolean autoDelete, Map<String, String> config, Handler<AsyncResult<JsonObject>> resultHandler) {
     forChannel(resultHandler, channel -> {

--- a/src/main/java/io/vertx/rabbitmq/package-info.java
+++ b/src/main/java/io/vertx/rabbitmq/package-info.java
@@ -57,6 +57,15 @@
  * {@link examples.Examples#exchangeDeclareWithConfig(io.vertx.rabbitmq.RabbitMQClient)}
  * ----
  *
+ * === Declare queue with additional config
+ *
+ * You can pass additional config parameters to RabbitMQs queueDeclare method
+ *
+ * [source, $lang]
+ * ----
+ * {@link examples.Examples#queueDeclareWithConfig(io.vertx.rabbitmq.RabbitMQClient)}
+ * ----
+ *
  * == Operations
  *
  * The following are some examples of the operations supported by the RabbitMQService API.
@@ -79,7 +88,7 @@
  * ----
  * {@link examples.Examples#basicPublishWithConfirm}
  * ----
- * 
+ *
  * === Consume
  *
  * Consume messages from a queue

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQServiceTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQServiceTest.java
@@ -262,6 +262,26 @@ public class RabbitMQServiceTest extends VertxTestBase {
     await();
   }
 
+//  @Test
+//  public void testQueueDeclareAndDeleteWithConfig() {
+//    String queueName = randomAlphaString(10);
+//    JsonObject config = new JsonObject();
+//    config.put("x-message-ttl", 10_000L);
+//
+//    client.queueDeclare(queueName, false, false, true, config, asyncResult -> {
+//      assertTrue(asyncResult.succeeded());
+//      JsonObject result = asyncResult.result();
+//      assertEquals(result.getString("queue"), queueName);
+//
+//      client.queueDelete(queueName, deleteAsyncResult -> {
+//        assertTrue(deleteAsyncResult.succeeded());
+//        testComplete();
+//      });
+//    });
+//
+//    await();
+//  }
+
   //TODO: create an integration test with a test scenario
   @Test
   public void testDeclareExchangeWithAlternateExchange() throws Exception {

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQServiceTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQServiceTest.java
@@ -262,25 +262,25 @@ public class RabbitMQServiceTest extends VertxTestBase {
     await();
   }
 
-//  @Test
-//  public void testQueueDeclareAndDeleteWithConfig() {
-//    String queueName = randomAlphaString(10);
-//    JsonObject config = new JsonObject();
-//    config.put("x-message-ttl", 10_000L);
-//
-//    client.queueDeclare(queueName, false, false, true, config, asyncResult -> {
-//      assertTrue(asyncResult.succeeded());
-//      JsonObject result = asyncResult.result();
-//      assertEquals(result.getString("queue"), queueName);
-//
-//      client.queueDelete(queueName, deleteAsyncResult -> {
-//        assertTrue(deleteAsyncResult.succeeded());
-//        testComplete();
-//      });
-//    });
-//
-//    await();
-//  }
+  @Test
+  public void testQueueDeclareAndDeleteWithConfig() {
+    String queueName = randomAlphaString(10);
+    JsonObject config = new JsonObject();
+    config.put("x-message-ttl", 10_000L);
+
+    client.queueDeclare(queueName, false, false, true, config, asyncResult -> {
+      assertTrue(asyncResult.succeeded());
+      JsonObject result = asyncResult.result();
+      assertEquals(result.getString("queue"), queueName);
+
+      client.queueDelete(queueName, deleteAsyncResult -> {
+        assertTrue(deleteAsyncResult.succeeded());
+        testComplete();
+      });
+    });
+
+    await();
+  }
 
   //TODO: create an integration test with a test scenario
   @Test


### PR DESCRIPTION
This is for #38 

Basically adds support for more or less arbitrary types in for config values when declaring exchanges or queues. 
This uses the Vert.x `JsonObject` so is following the same kind of style as other Vert.x code.

I added an example for declaring a queue and quick test to show it compiling and working with a non-string value and deprecated the previous `Map<String, String>` methods. As mentioned in #38 Generated code is more or less the same with the exception of Kotlin. Given the warning in the documentation about APIs changing and Kotlin being a relatively new programming language I think this is acceptable.

Lyndon