### PR TITLE
Upgrade rabbitmq version to 5.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
 
   <properties>
     <stack.version>3.6.0-SNAPSHOT</stack.version>
-    <rabbitmq.client.version>3.6.5</rabbitmq.client.version>
+    <rabbitmq.client.version>5.2.0</rabbitmq.client.version>
+    <slf4j.version>1.7.16</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -44,11 +45,21 @@
       <artifactId>vertx-docgen</artifactId>
       <optional>true</optional>
     </dependency>
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
       <version>${rabbitmq.client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Testing -->


### PR DESCRIPTION
A solution for #60 

**Changes**:
* rabbitmq-client: 3.6.5->5.2.0
* slf4j-api:1.7.25(rabbitmq-client trasitive dependecy) was exclueded from the classpath since  vert.x stack manager uses version 1.7.16 
*  slf4j-api:1.7.16 inclueded into the classpath