### PR TITLE
Codecov support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "0...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ services:
   - rabbitmq
 jdk:
   - oraclejdk8
-  - oraclejdk9
 
 before_install:
   - cp .travis.maven.settings.xml $HOME/.m2/settings.xml
 
 script:
   - set -e
-  - mvn clean verify -Prabbitmq.local
+  - mvn clean verify -Prabbitmq.local,coverage
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RabbitMQ Client for Vert.x
 
 [![Build Status](https://vertx.ci.cloudbees.com/buildStatus/icon?job=vert.x3-rabbitmq-client)](https://vertx.ci.cloudbees.com/view/vert.x-3/job/vert.x3-rabbitmq-client/)
+[![codecov](https://codecov.io/gh/vert-x3/vertx-rabbitmq-client/branch/master/graph/badge.svg)](https://codecov.io/gh/Sammers21/vertx-rabbitmq-client)
 
 A Vert.x client allowing applications to interact with a RabbitMQ broker (AMQP 0.9.1)
 


### PR DESCRIPTION
Changes:

- removed build for JDK 9 since it is not working fine with jacoco coverage plugin. Here you can find the error I get when trying to run jacoco on Java 9: https://travis-ci.org/Sammers21/vertx-rabbitmq-client/jobs/374387868

- added codecov.io support, so each PR will have a report on code coverage in the format: 
![image](https://user-images.githubusercontent.com/16746106/39580275-72ba7ee8-4ef1-11e8-876d-70c173b038fe.png)

The report also will be updated on each commit.
