### PR TITLE
Allow to use multiple adresses to connect to RabbitMQ cluster

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -46,6 +46,13 @@ Or you can also specify individual parameters manually:
 {@link examples.RabbitMQExamples#createClientWithManualParams}
 ----
 
+You can set multiples addresses to connect to a cluster;
+
+[source,$lang]
+----
+{@link examples.RabbitMQExamples#createClientWithMultipleHost}
+----
+
 === Declare exchange with additional config
 
 You can pass additional config parameters to RabbitMQ's exchangeDeclare method

--- a/src/main/java/examples/RabbitMQExamples.java
+++ b/src/main/java/examples/RabbitMQExamples.java
@@ -1,5 +1,6 @@
 package examples;
 
+import com.rabbitmq.client.Address;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rabbitmq.QueueOptions;
@@ -7,8 +8,7 @@ import io.vertx.rabbitmq.RabbitMQClient;
 import io.vertx.rabbitmq.RabbitMQConsumer;
 import io.vertx.rabbitmq.RabbitMQOptions;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
 
 public class RabbitMQExamples {
 
@@ -34,6 +34,18 @@ public class RabbitMQExamples {
     config.setRequestedChannelMax(5);
     config.setNetworkRecoveryInterval(500); // in milliseconds
     config.setAutomaticRecoveryEnabled(true);
+
+    RabbitMQClient client = RabbitMQClient.create(vertx, config);
+  }
+
+  //pass multiple hosts to client, allow to use a clustered RabbitMQ
+  public void createClientWithMultipleHost(Vertx vertx) {
+    RabbitMQOptions config = new RabbitMQOptions();
+    config.setUser("user1");
+    config.setPassword("password1");
+    config.setVirtualHost("vhost1");
+
+    config.setAddresses(Arrays.asList(Address.parseAddresses("firstHost,secondHost:5672")));
 
     RabbitMQClient client = RabbitMQClient.create(vertx, config);
   }
@@ -216,7 +228,6 @@ public class RabbitMQExamples {
         queueResult.cause().printStackTrace();
       }
     });
-
   }
 
 }

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -1,8 +1,13 @@
 package io.vertx.rabbitmq;
 
+import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * RabbitMQ client options, most
@@ -80,6 +85,7 @@ public class RabbitMQOptions {
   private Integer connectionRetries = DEFAULT_CONNECTION_RETRIES;
   private long connectionRetryDelay = DEFAULT_CONNECTION_RETRY_DELAY;
   private String uri = null;
+  private List<Address> addresses = Collections.emptyList();
   private String user = DEFAULT_USER;
   private String password = DEFAULT_PASSWORD;
   private String host = DEFAULT_HOST;
@@ -105,6 +111,7 @@ public class RabbitMQOptions {
     connectionRetries = that.connectionRetries;
     connectionRetryDelay = that.connectionRetryDelay;
     uri = that.uri;
+    addresses = that.addresses;
     user = that.user;
     password = that.password;
     host = that.host;
@@ -152,6 +159,20 @@ public class RabbitMQOptions {
    */
   public RabbitMQOptions setConnectionRetryDelay(long connectionRetryDelay) {
     this.connectionRetryDelay = connectionRetryDelay;
+    return this;
+  }
+
+  public List<Address> getAddresses() {
+    return Collections.unmodifiableList(addresses);
+  }
+
+  /**
+   * Set multiple addresses for cluster mode.
+   * @param addresses addresses of AMQP cluster
+   * @return a reference to this, so the API can be used fluently
+   */
+  public RabbitMQOptions setAddresses(List<Address> addresses) {
+    this.addresses = new ArrayList<>(addresses);
     return this;
   }
 


### PR DESCRIPTION
Hello,

It seems to be impossible to connect to a RabbitMQ cluster (like describe in #8). I think it can possible to add a collection of addresses in `RabbitMQOptions`. I suggest this solution.

Do you think that is the good way?

Thank you