### PR TITLE
#30: Added support for headers that are maps

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/impl/Utils.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/Utils.java
@@ -96,6 +96,10 @@ class Utils {
    */
   private static Object convertLongStringToString( Object value ) {
 
+    if ( value instanceof Date ) {
+      return ((Date) value).toInstant();
+    }
+
     if ( value instanceof LongString ) {
       return value.toString();
     }
@@ -106,6 +110,10 @@ class Utils {
         newList.add( convertLongStringToString( item ) );
       }
       return newList;
+    }
+
+    if ( value instanceof Map) {
+      return convertMapLongStringToString((Map<String, Object>) value);
     }
 
     return value;


### PR DESCRIPTION
This should fix the issue in #3 and in #30, as the deserialization was ignoring maps nested inside a header (e.g. `x-death` parameters)