### PR TITLE
Root cause lost when rethrowing

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -90,7 +90,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
         log.info("Connecting to " + uri);
         cf.setUri(uri);
       } catch (Exception e) {
-        throw new IllegalArgumentException("Invalid rabbitmq connection uri " + uri);
+        throw new IllegalArgumentException("Invalid rabbitmq connection uri ", e);
       }
     } else {
       cf.setUsername(config.getUser());

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import javax.net.ssl.SSLHandshakeException;
 
@@ -40,6 +41,18 @@ public class RabbitMQClientTLSConnectTest extends RabbitMQClientTestBaseTLS {
 		return config;
 	}
 
+	@Test
+	public void shouldPropagateCausingExeption(TestContext ctx) throws Throwable {
+		try {
+		  connect(new RabbitMQOptions()
+				.setUri("amqp://" + rabbitmq.getContainerIpAddress() + ": A32")
+				);
+		}catch(Exception e) {
+			assertTrue(ExceptionUtils.getRootCause(e) instanceof URISyntaxException);
+		}		
+	}
+
+	
 	@Test
 	public void shouldConnectWithoutHostVerification(TestContext ctx) throws Exception {
 		connect(config()

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.shaded.org.apache.commons.lang.exception.ExceptionUtils;
 
 import io.vertx.ext.unit.TestContext;
 import io.vertx.test.tls.Trust;


### PR DESCRIPTION
Root cause is lost when Illegal argument exception is thrown.

This closes Issue: **More information when invalid rabbitmq uri #81**