### PR TITLE
Expose the flag in RabbitMQOptions to enable NIO Sockets the client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <stack.version>4.0.3-SNAPSHOT</stack.version>
-    <rabbitmq.client.version>5.9.0</rabbitmq.client.version>
+    <rabbitmq.client.version>5.10.0</rabbitmq.client.version>
     <slf4j.version>1.7.21</slf4j.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>

--- a/src/main/generated/io/vertx/rabbitmq/RabbitMQOptionsConverter.java
+++ b/src/main/generated/io/vertx/rabbitmq/RabbitMQOptionsConverter.java
@@ -16,6 +16,16 @@ public class RabbitMQOptionsConverter {
   public static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, RabbitMQOptions obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
+        case "applicationLayerProtocols":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setApplicationLayerProtocols(list);
+          }
+          break;
         case "automaticRecoveryEnabled":
           if (member.getValue() instanceof Boolean) {
             obj.setAutomaticRecoveryEnabled((Boolean)member.getValue());
@@ -124,6 +134,8 @@ public class RabbitMQOptionsConverter {
           if (member.getValue() instanceof Number) {
             obj.setNetworkRecoveryInterval(((Number)member.getValue()).longValue());
           }
+          break;
+        case "nioEnabled":
           break;
         case "openSslEngineOptions":
           if (member.getValue() instanceof JsonObject) {
@@ -275,6 +287,11 @@ public class RabbitMQOptionsConverter {
             obj.setUseAlpn((Boolean)member.getValue());
           }
           break;
+        case "useNio":
+          if (member.getValue() instanceof Boolean) {
+            obj.setUseNio((Boolean)member.getValue());
+          }
+          break;
         case "user":
           if (member.getValue() instanceof String) {
             obj.setUser((String)member.getValue());
@@ -294,6 +311,11 @@ public class RabbitMQOptionsConverter {
   }
 
   public static void toJson(RabbitMQOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getApplicationLayerProtocols() != null) {
+      JsonArray array = new JsonArray();
+      obj.getApplicationLayerProtocols().forEach(item -> array.add(item));
+      json.put("applicationLayerProtocols", array);
+    }
     json.put("automaticRecoveryEnabled", obj.isAutomaticRecoveryEnabled());
     json.put("connectTimeout", obj.getConnectTimeout());
     json.put("connectionTimeout", obj.getConnectionTimeout());
@@ -343,6 +365,7 @@ public class RabbitMQOptionsConverter {
       json.put("metricsName", obj.getMetricsName());
     }
     json.put("networkRecoveryInterval", obj.getNetworkRecoveryInterval());
+    json.put("nioEnabled", obj.isNioEnabled());
     if (obj.getOpenSslEngineOptions() != null) {
       json.put("openSslEngineOptions", obj.getOpenSslEngineOptions().toJson());
     }

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -85,6 +85,11 @@ public class RabbitMQOptions extends NetClientOptions {
    */
   public static final long DEFAULT_RECONNECT_INTERVAL = 10000L;
 
+  /**
+   * The default use nio sockets = {@code false}
+   */
+  public static final boolean DEFAULT_USE_NIO_SOCKETS = false;
+
   private String uri = null;
   private List<Address> addresses = Collections.emptyList();
   private String user;
@@ -99,6 +104,7 @@ public class RabbitMQOptions extends NetClientOptions {
   private long networkRecoveryInterval;
   private boolean automaticRecoveryEnabled;
   private boolean includeProperties;
+  private boolean useNio;
 
   public RabbitMQOptions() {
     super();
@@ -128,6 +134,7 @@ public class RabbitMQOptions extends NetClientOptions {
     this.automaticRecoveryEnabled = other.automaticRecoveryEnabled;
     this.includeProperties = other.includeProperties;
     this.requestedChannelMax = other.requestedChannelMax;
+    this.useNio = other.useNio;
   }
 
   private void init() {
@@ -145,6 +152,7 @@ public class RabbitMQOptions extends NetClientOptions {
     this.networkRecoveryInterval = DEFAULT_NETWORK_RECOVERY_INTERNAL;
     this.automaticRecoveryEnabled = DEFAULT_AUTOMATIC_RECOVERY_ENABLED;
     this.includeProperties = false;
+    this.useNio = DEFAULT_USE_NIO_SOCKETS;
   }
 
 
@@ -385,6 +393,24 @@ public class RabbitMQOptions extends NetClientOptions {
    */
   public RabbitMQOptions setIncludeProperties(boolean includeProperties) {
     this.includeProperties = includeProperties;
+    return this;
+  }
+
+  /**
+   * @return {@code true} if NIO Sockets are enabled, {@code false} otherwise
+   */
+  public boolean isNioEnabled() {
+    return useNio;
+  }
+
+  /**
+   * Enables or disables usage of NIO Sockets.
+   *
+   * @param useNio if {@code true}, enables NIO Sockets
+   * @return a reference to this, so the API can be used fluently
+   */
+  public RabbitMQOptions setUseNio(boolean useNio) {
+    this.useNio = useNio;
     return this;
   }
 

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -115,6 +115,11 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     	JdkSslContext ctx = (JdkSslContext)sslHelper.getContext((VertxInternal)vertx);
       cf.useSslProtocol(ctx.context());
     }
+
+    if (config.isNioEnabled()) {
+      cf.useNio();
+    }
+
     //TODO: Support other configurations
 
     return addresses == null

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQOptionsTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQOptionsTest.java
@@ -29,7 +29,8 @@ public class RabbitMQOptionsTest {
     int expectedNetworkRecoveryInterval = TestUtils.randomPositiveInt();
     boolean expectedAutomaticRecoveryEnabled = TestUtils.randomBoolean();
     boolean expectedIncludeProperties = TestUtils.randomBoolean();
-   
+    boolean useNio = TestUtils.randomBoolean();
+
     JsonObject json = new JsonObject();
     json.put("uri", expectedUri);
     json.put("user", expectedUser);
@@ -44,6 +45,7 @@ public class RabbitMQOptionsTest {
     json.put("networkRecoveryInterval", expectedNetworkRecoveryInterval);
     json.put("automaticRecoveryEnabled", expectedAutomaticRecoveryEnabled);
     json.put("includeProperties", expectedIncludeProperties);
+    json.put("useNio", useNio);
     RabbitMQOptions options = new RabbitMQOptions();
     assertSame(options, options.setUri(expectedUri));
     assertSame(options, options.setUser(expectedUser));
@@ -58,7 +60,8 @@ public class RabbitMQOptionsTest {
     assertSame(options, options.setNetworkRecoveryInterval(expectedNetworkRecoveryInterval));
     assertSame(options, options.setAutomaticRecoveryEnabled(expectedAutomaticRecoveryEnabled));
     assertSame(options, options.setIncludeProperties(expectedIncludeProperties));
-    
+    assertSame(options, options.setUseNio(useNio));
+
     for (RabbitMQOptions testOptions : Arrays.asList(new RabbitMQOptions(json), new RabbitMQOptions(options))) {
       assertEquals(testOptions.getUri(), expectedUri);
       assertEquals(testOptions.getUser(), expectedUser);
@@ -73,6 +76,7 @@ public class RabbitMQOptionsTest {
       assertEquals(testOptions.getNetworkRecoveryInterval(), expectedNetworkRecoveryInterval);
       assertEquals(testOptions.isAutomaticRecoveryEnabled(), expectedAutomaticRecoveryEnabled);
       assertEquals(testOptions.getIncludeProperties(), expectedIncludeProperties);
+      assertEquals(testOptions.isNioEnabled(), useNio);
      }
   }
 }


### PR DESCRIPTION
Motivation:

In production we have noticed that the underlying sockets in the RabbitMQ client can block when there are network losses for long periods causing heartbeat failures and not recovering quickly using the autorecovery capability (See rabbitmq/rabbitmq-java-client#236)

The RabbitMQ Client has the option to use NIO Sockets are well, and they do not suffer from the same problem as they signal network timeouts much faster, allowing the client to recover gracefully.

This change allows enabling that option in the underlying RabbitMQ client.

In addition I have upgrade the RabbitMQ Client to the latest available version and also the Test Containers library as it fails with modern versions of Docker.

