### PR TITLE
Enable inheritConverter for RabbitMQOptions.

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -22,7 +22,7 @@ import io.vertx.core.net.TrustOptions;
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@DataObject(generateConverter = true)
+@DataObject(generateConverter = true, inheritConverter = true)
 public class RabbitMQOptions extends NetClientOptions {
 
   /**


### PR DESCRIPTION
Motivation:

https://github.com/vert-x3/vertx-rabbitmq-client/issues/112
Without inheritConverters loading RabbitMQOptions from JSON is pretty well broken.
