### PR TITLE
Update testcontainers version to fix build error on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         jdk: [8, 11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         jdk: [8, 11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         os: [ubuntu-latest]
         jdk: [8, 11]
     runs-on: ${{ matrix.os }}
+    env:
+      MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.10.1</version>
+      <version>1.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.10.5</version>
+      <version>1.15.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <stack.version>4.0.1-SNAPSHOT</stack.version>
-    <rabbitmq.client.version>5.9.0</rabbitmq.client.version>
+    <rabbitmq.client.version>5.10.0</rabbitmq.client.version>
     <slf4j.version>1.7.21</slf4j.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <stack.version>4.0.1-SNAPSHOT</stack.version>
-    <rabbitmq.client.version>5.10.0</rabbitmq.client.version>
+    <rabbitmq.client.version>5.9.0</rabbitmq.client.version>
     <slf4j.version>1.7.21</slf4j.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.15.1</version>
+      <version>1.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.15.0</version>
+      <version>1.15.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSMutualAuthConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSMutualAuthConnectTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import javax.net.ssl.SSLHandshakeException;
-
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -16,6 +14,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import io.vertx.core.net.JksOptions;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.test.tls.Cert;
+import javax.net.ssl.SSLException;
 
 /**
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
@@ -71,7 +70,7 @@ public class RabbitMQClientTLSMutualAuthConnectTest extends RabbitMQClientTestBa
       fail("Should have thrown exception");
     } catch (Exception e) {
       assertFalse(client.isConnected());
-      assertTrue("Was expecting " + e.getCause() + " to be an instance of SSLHandshakeException", e.getCause() instanceof SSLHandshakeException);
+      assertTrue("Was expecting " + e.getCause() + " to be an instance of SSLException", e.getCause() instanceof SSLException);
     }
   }
 }

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
@@ -270,7 +270,7 @@ public class RabbitMQClientTransientQueueTest extends RabbitMQClientTestBase {
     }
     
     logger.info("Waiting up to 20s for the latch");
-    receivedLastMessageLatch.await(40000L);
+    receivedLastMessageLatch.await(60000L);
     logger.info("Latched, shutting down");
 
     List<String> got = new ArrayList<>(messagesReceived.keySet());

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
@@ -53,7 +53,7 @@ public class RabbitMQClientTransientQueueTest extends RabbitMQClientTestBase {
   public RabbitMQOptions config() throws Exception {
     RabbitMQOptions options = super.config();
     options.setUri("amqp://" + fixedRabbitmq.getContainerIpAddress() + ":" + fixedRabbitmq.getMappedPort(5672));
-    options.setAutomaticRecoveryEnabled(true);
+    options.setAutomaticRecoveryEnabled(false);
     options.setReconnectAttempts(Integer.MAX_VALUE);
     options.setReconnectInterval(500);
     return options;

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
@@ -11,7 +11,6 @@ import io.vertx.ext.unit.TestContext;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -271,7 +270,7 @@ public class RabbitMQClientTransientQueueTest extends RabbitMQClientTestBase {
     }
     
     logger.info("Waiting up to 20s for the latch");
-    receivedLastMessageLatch.await(20000L);
+    receivedLastMessageLatch.await(40000L);
     logger.info("Latched, shutting down");
 
     List<String> got = new ArrayList<>(messagesReceived.keySet());

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTransientQueueTest.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQConsumptionStreamingTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQConsumptionStreamingTest.java
@@ -94,7 +94,10 @@ public class RabbitMQConsumptionStreamingTest extends RabbitMQClientTestBase {
     client.basicConsumer(q, ctx.asyncAssertSuccess(consumer -> {
       consumer.endHandler(v -> endOfStream.complete());
       consumer.handler(msg -> ctx.fail());
-      consumer.cancel(ctx.asyncAssertSuccess(v -> canceled.complete()));
+      vertx.executeBlocking(p -> {
+        consumer.cancel(ctx.asyncAssertSuccess(v -> canceled.complete()));
+        p.complete();
+      });
     }));
 
     canceled.awaitSuccess(15000);


### PR DESCRIPTION
Motivation:

https://github.com/vert-x3/vertx-rabbitmq-client/issues/113
Update version of testcontainers to fix build error on Windows.

