### PR TITLE
https://github.com/vert-x3/vertx-rabbitmq-client/issues/116

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>toxiproxy</artifactId>
+      <version>1.15.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.25</version>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -53,23 +53,43 @@ You can set multiples addresses to connect to a cluster;
 {@link examples.RabbitMQExamples#createClientWithMultipleHost}
 ----
 
-Reconnections
+=== Recovery and Reconnections
 
-The RabbitMQClient will, by default, retry connecting to the RabbitMQ server if it cannot connect.
-It will also attempt to reconnect whenever the connection to the RabbitMQ server becomes broken.
+There are two, separate and incompatible, mechanisms for handling reconnections in the RabbitMQClient:
+
+* Java RabbitMQ client library auto recovery;
+* RabbitMQClient restarts.
+
+Neither mechanism is enabled by default.
+
+The reconnections provided by the Java RabbitMQ client library do not work in all situations (if the connection to the server disconnects nicely the client will shut down and not recover).
+----
+[source, java]
+In order to use the Java RabbitMQ client library auto recovery it is necessary to both enable it and disable the RabbitMQClient library reconnect attempts:
+RabbitMQOptions options = new RabbitMQOptions();
+options.setAutomaticRecoveryEnabled(true);
+options.setReconnectAttempts(0);
+----
+The client library will also attempt topology recovery as detailed in its documentation (this is enabled by default in the library and is not exposed in the RabbitMQClientOptions).
+
+
+
+Alternatively the RabbitMQClient may be configured to retry connecting to the RabbitMQ server whenever there is a connection problem.
 The failure of a connection could be caused by a transient network failure (where the client would probably connect back to the same RabbitMQ server) or it could be caused by a failover scenario.
+This approach is more brutal than that followed by the client library - the RabbitMQClient restarts work by closing the connections when the client library reports a problem and then repeatedly trying to reconnect from scratch.
 
 The reconnection policy can be configured by setting the {@link io.vertx.core.net.NetClientOptions#setReconnectInterval(long)} and
 {@link io.vertx.core.net.NetClientOptions#setReconnectAttempts(int)} properties in the configuration:
 [source, java]
 ----
-RabbitMQOptions config = new RabbitMQOptions();
+RabbitMQOptions options = new RabbitMQOptions();
+options.setAutomaticRecoveryEnabled(false);
 options.setReconnectAttempts(Integer.MAX_VALUE);
 options.setReconnectInterval(500);
 ----
 
-As soon as the connection has been re-established users of the client may attempt to publish (or consume) messages.
-However, if the connection is to a new RabbitMQ server it is possible that objects created through this RabbitMQClient won't exist,. i.e. when exchanges and queues are created through the RabbitMQClient on startup.
+The RabbitMQClient reconnections do not feature any form of _automatic_ topology recovery.
+This can lead to a race condition where messages are sent before the topology on the server is ready (i.e. before exchanges and queues have been created/bound).
 To provide an opportunity to create these objects before the connection is considered ready the RabbitMQClient provides the ConnectionEstablishedCallback.
 The ConnectionEstablishedCallback can be used to carry out any operations on the RabbitMQClient before other users (including the RabbitMQConsumer and RabbitMQPublisher) are able to access it.
 

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -223,9 +223,11 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     return forChannel(channel -> {
       log.debug("Created new QueueConsumer");
       QueueConsumerHandler handler = new QueueConsumerHandler(vertx, channel, options, queue);
-      handler.setShutdownHandler(sig -> {
-        restartConsumer(0, handler, options);
-      });
+      if (retries > 0) {
+        handler.setShutdownHandler(sig -> {
+          restartConsumer(0, handler, options);
+        });
+      }
       try {
         channel.basicConsume(queue, options.isAutoAck(), handler);
       } catch(Throwable ex) {

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientBuiltInReconnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientBuiltInReconnectTest.java
@@ -28,280 +28,259 @@ import org.testcontainers.utility.DockerImageName;
 import static com.rabbitmq.client.BuiltinExchangeType.FANOUT;
 import static org.junit.Assert.assertEquals;
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
-/**
- *
- * @author jtalbut
- */
 @RunWith(VertxUnitRunner.class)
 public class RabbitMQClientBuiltInReconnectTest {
-  
+
   /**
-   * This test verifies that the RabbitMQ Java client reconnection logic works 
-   * as long as the vertx reconnect attempts is set to zero.
-   * 
-   * The change that makes this work is in the basicConsumer, where the shutdown handler
-   * is only set if retries > 0.
-   * Without that change the vertx client shutdown handler is called, interrupting the java
-   * client reconnection logic, even though the vertx reconnection won't work because retries is zero.
-   * 
+   * This test verifies that the RabbitMQ Java client reconnection logic works as long as the vertx reconnect attempts is set to zero.
+   *
+   * The change that makes this work is in the basicConsumer, where the shutdown handler is only set if retries > 0. 
+   * Without that change the vertx client shutdown handler is called, 
+   * interrupting the java client reconnection logic, even though the vertx reconnection won't work because retries is zero.
+   *
    */
-  
-    private static final String TEST_EXCHANGE = "RabbitMQClientBuiltInReconnectExchange";
-    private static final String TEST_QUEUE = "RabbitMQClientBuiltInReconnectQueue";
-    private static final String TEST_MESSAGE = "My Message";
-    private static final boolean DEFAULT_RABBITMQ_EXCHANGE_DURABLE = false;
-    private static final boolean DEFAULT_RABBITMQ_EXCHANGE_EXCLUSIVE = true;
-    private static final boolean DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE = true;
-    private static final String DEFAULT_RABBITMQ_EXCHANGE_TYPE = FANOUT.getType();
-  
-    public class RabbitMQMessageProducer {
+  private static final String TEST_EXCHANGE = "RabbitMQClientBuiltInReconnectExchange";
+  private static final String TEST_QUEUE = "RabbitMQClientBuiltInReconnectQueue";
+  private static final String TEST_MESSAGE = "My Message";
+  private static final boolean DEFAULT_RABBITMQ_EXCHANGE_DURABLE = false;
+  private static final boolean DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE = true;
+  private static final String DEFAULT_RABBITMQ_EXCHANGE_TYPE = FANOUT.getType();
+  private static final boolean DEFAULT_RABBITMQ_QUEUE_DURABLE = false;
+  private static final boolean DEFAULT_RABBITMQ_QUEUE_EXCLUSIVE = true;
+  private static final boolean DEFAULT_RABBITMQ_QUEUE_AUTO_DELETE = true;
 
-        private final RabbitMQClient rabbitMQClient;
+  public class RabbitMQMessageProducer {
 
-        private final String topic;
+    private final RabbitMQClient rabbitMQClient;
 
-        public RabbitMQMessageProducer(RabbitMQClient rabbitMQClient, String topic) {
-            this.rabbitMQClient = rabbitMQClient;
-            this.topic = topic;
-        }
+    private final String topic;
 
-        public Future<Void> setUp() {
-            return rabbitMQClient.start()
-                    .compose(aVoid -> rabbitMQClient.exchangeDeclare(topic, 
-                            DEFAULT_RABBITMQ_EXCHANGE_TYPE,
-                            DEFAULT_RABBITMQ_EXCHANGE_DURABLE,
-                            DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE))
-                    .onSuccess(result -> {
-                        LOGGER.info("Created exchange '{}': {}", topic, result);
-                    })
-                    .compose(aVoid -> rabbitMQClient.confirmSelect())
-                    .onSuccess(result -> LOGGER.info("Confirmation enabled for topic {}", topic))
-                    .onFailure(throwable -> LOGGER.warn("Failed to create exchange '{}'", topic, throwable))
-                    ;
-        }
-
-        public void send(String message) {
-            LOGGER.info("Sending message {} to RabbitMQ topic {}", message, topic);
-            byte[] messageAsBytes = encode(message);
-
-            rabbitMQClient
-                    .basicPublish(topic, "", Buffer.buffer(messageAsBytes))
-                    .compose(aVoid -> rabbitMQClient.waitForConfirms(60000))
-                    .onSuccess(aVoid -> LOGGER.debug("Published message {} to RabbitMQ topic {}", message, topic))
-                    .onFailure(throwable -> LOGGER.warn("Failed to publish message {} to RabbitMQ topic {}", message, topic, throwable))
-                    ;
-        }
-
-        public Future<Void> close() {
-            return rabbitMQClient.stop();
-        }
+    public RabbitMQMessageProducer(RabbitMQClient rabbitMQClient, String topic) {
+      this.rabbitMQClient = rabbitMQClient;
+      this.topic = topic;
     }
-  
-    public static class RabbitMqConsumer {
-        private RabbitMQClient client;
 
-        public RabbitMqConsumer(Vertx vertx) {
-            RabbitMQOptions config = new RabbitMQOptions();
-            client = RabbitMQClient.create(vertx, config);
-        }
-
-        public void listen() {
-
-            // Connect
-            client.start(asyncResult -> {
-                if (asyncResult.succeeded()) {
-                    System.out.println("RabbitMQ successfully connected!");
-                } else {
-                    System.out.println("Fail to connect to RabbitMQ " + asyncResult.cause().getMessage());
-                }
-            });
-        }
+    public Future<Void> setUp() {
+      return rabbitMQClient.start()
+              .compose(aVoid -> rabbitMQClient.exchangeDeclare(topic,
+                      DEFAULT_RABBITMQ_EXCHANGE_TYPE,
+                      DEFAULT_RABBITMQ_EXCHANGE_DURABLE,
+                      DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE
+              ))
+              .onSuccess(result -> {
+                LOGGER.info("Created exchange '{}': {}", topic, result);
+              })
+              .compose(aVoid -> rabbitMQClient.confirmSelect())
+              .onSuccess(result -> LOGGER.info("Confirmation enabled for topic {}", topic))
+              .onFailure(throwable -> LOGGER.warn("Failed to create exchange '{}'", topic, throwable));
     }
-  
-  
-    private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQClientBuiltInReconnectTest.class);
 
-    AtomicLong producerTimeReference = new AtomicLong();
-    AtomicReference<RabbitMQMessageProducer> producerReference = new AtomicReference<>();
-    AtomicReference<RabbitMQClient> consumerReference = new AtomicReference<>();
-    AtomicReference<Handler<AsyncResult<String>>> handlerReference = new AtomicReference<>();
+    public void send(String message) {
+      LOGGER.info("Sending message {} to RabbitMQ topic {}", message, topic);
+      byte[] messageAsBytes = encode(message);
 
-    private final ObjectMapper mapper;
-    private final Network network;
-    private final GenericContainer networkedRabbitmq;
-    private final ToxiproxyContainer toxiproxy;
+      rabbitMQClient
+              .basicPublish(topic, "", Buffer.buffer(messageAsBytes))
+              .compose(aVoid -> rabbitMQClient.waitForConfirms(60000))
+              .onSuccess(aVoid -> LOGGER.debug("Published message {} to RabbitMQ topic {}", message, topic))
+              .onFailure(throwable -> LOGGER.warn("Failed to publish message {} to RabbitMQ topic {}", message, topic, throwable));
+    }
 
-    public RabbitMQClientBuiltInReconnectTest() {
-      LOGGER.info("Constructing");
-      this.mapper =  new ObjectMapper();
-      this.network = Network.newNetwork();
-      this.networkedRabbitmq = new GenericContainer(DockerImageName.parse("rabbitmq:3.8.6-alpine"))
+    public Future<Void> close() {
+      return rabbitMQClient.stop();
+    }
+  }
+
+  public static class RabbitMqConsumer {
+
+    private final RabbitMQClient client;
+
+    public RabbitMqConsumer(Vertx vertx) {
+      RabbitMQOptions config = new RabbitMQOptions();
+      client = RabbitMQClient.create(vertx, config);
+    }
+
+    public void listen() {
+      client.start().onFailure(ex -> LOGGER.error("Fail to connect to RabbitMQ ", ex));
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQClientBuiltInReconnectTest.class);
+
+  private final AtomicLong producerTimeReference = new AtomicLong();
+  private final AtomicReference<RabbitMQMessageProducer> producerReference = new AtomicReference<>();
+  private final AtomicReference<RabbitMQClient> consumerReference = new AtomicReference<>();
+  private final AtomicReference<Handler<AsyncResult<String>>> handlerReference = new AtomicReference<>();
+
+  private final ObjectMapper mapper;
+  private final Network network;
+  private final GenericContainer networkedRabbitmq;
+  private final ToxiproxyContainer toxiproxy;
+
+  public RabbitMQClientBuiltInReconnectTest() {
+    LOGGER.info("Constructing");
+    this.mapper = new ObjectMapper();
+    this.network = Network.newNetwork();
+    this.networkedRabbitmq = new GenericContainer(DockerImageName.parse("rabbitmq:3.8.6-alpine"))
             .withExposedPorts(5672)
             .withNetwork(network);
-      this.toxiproxy = new ToxiproxyContainer(DockerImageName.parse("shopify/toxiproxy:2.1.0"))
+    this.toxiproxy = new ToxiproxyContainer(DockerImageName.parse("shopify/toxiproxy:2.1.0"))
             .withNetwork(network);
+  }
+
+  @Before
+  public void setup() {
+    LOGGER.info("Starting");
+    this.networkedRabbitmq.start();
+    this.toxiproxy.start();
+  }
+
+  @After
+  public void shutdown() {
+    this.networkedRabbitmq.stop();
+    this.toxiproxy.stop();
+    LOGGER.info("Shutdown");
+  }
+
+  @Test(timeout = 1 * 60 * 1000L)
+  public void testRecoverConnectionOutage(TestContext ctx) throws Exception {
+    Vertx vertx = Vertx.vertx();
+    createAndStartProducer(vertx);
+
+    Async async = ctx.async();
+    Handler<AsyncResult<String>> secondMessageHandler = result1 -> {
+      LOGGER.info("Got another message. Connection recovery was successful.");
+      vertx.cancelTimer(producerTimeReference.get());
+      producerReference.get().close();
+      consumerReference.get().stop();
+      async.complete();
+    };
+
+    Handler<AsyncResult<String>> firstMessageHandler = ar -> {
+      vertx.executeBlocking(f -> {
+        LOGGER.info("Got a message, Shutdown rabbitmq.");
+        networkedRabbitmq.stop();
+        f.complete();
+      }).compose(a -> {
+        return vertx.executeBlocking(f -> {
+          LOGGER.info("Restore RabbitMQ and wait for one more message.");
+          networkedRabbitmq.start();
+          handlerReference.set(secondMessageHandler);
+        });
+      });
+    };
+
+    handlerReference.set(firstMessageHandler);
+
+    Consumer<String> messageProcessor = message -> {
+      assertEquals(TEST_MESSAGE, message);
+      LOGGER.warn("Received message: {}", message);
+      handlerReference.get().handle(Future.succeededFuture());
+    };
+
+    createAndStartConsumer(vertx, consumerReference, messageProcessor);
+
+    LOGGER.info("Await message from rabbitmq.");
+
+  }
+
+  private void createAndStartProducer(Vertx vertx) {
+
+    RabbitMQOptions options = getRabbitMQOptions();
+
+    RabbitMQClient rabbitMQClient = RabbitMQClient.create(vertx, options);
+    RabbitMQMessageProducer rabbitMQMessageProducer = new RabbitMQMessageProducer(rabbitMQClient, TEST_EXCHANGE);
+    rabbitMQMessageProducer.setUp()
+            .onFailure(ex -> LOGGER.error("Failed to start consumer: ", ex))
+            .onSuccess(v -> {
+              LOGGER.info("Setting up periodic send");
+              vertx.setPeriodic(1000, unused -> rabbitMQMessageProducer.send(TEST_MESSAGE));
+              producerReference.set(rabbitMQMessageProducer);
+            }
+            );
+
+  }
+
+  private void createAndStartConsumer(Vertx vertx, AtomicReference<RabbitMQClient> consumerReference, Consumer<String> messageProcessor) {
+    createConsumer(vertx, messageProcessor)
+            .onSuccess(consumerReference::set)
+            .onFailure(ex -> LOGGER.error("Failed to start consumer: ", ex));
+  }
+
+  private <T> Future<RabbitMQClient> createConsumer(Vertx vertx, Consumer<String> processor) {
+    LOGGER.info("Registering RabbitMQ message consumer for exchange {}...", TEST_EXCHANGE);
+    RabbitMQOptions rabbitMQOptions = getRabbitMQOptions();
+    RabbitMQClient rabbitMQClient = RabbitMQClient.create(vertx, rabbitMQOptions);
+    return rabbitMQClient.start()
+            .compose(aVoid -> {
+              LOGGER.info("Consumer client started");
+              return rabbitMQClient.exchangeDeclare(TEST_EXCHANGE
+                       , DEFAULT_RABBITMQ_EXCHANGE_TYPE
+                       , DEFAULT_RABBITMQ_EXCHANGE_DURABLE
+                       , DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE
+              );
+            })
+            .compose(aVoid -> {
+              LOGGER.info("Exchange declared by consumer");
+              return rabbitMQClient.queueDeclare(TEST_QUEUE
+                       , DEFAULT_RABBITMQ_QUEUE_DURABLE
+                       , DEFAULT_RABBITMQ_QUEUE_EXCLUSIVE
+                       , DEFAULT_RABBITMQ_QUEUE_AUTO_DELETE
+              );
+            })
+            .compose(declareResult -> {
+              LOGGER.info("Queue declared by consumer");
+              return rabbitMQClient.queueBind(TEST_QUEUE, TEST_EXCHANGE, "");
+            })
+            .compose(aVoid -> {
+              LOGGER.info("Queue bound to exchange");
+              return rabbitMQClient.basicConsumer(TEST_QUEUE);
+            })
+            .map(rabbitMQConsumer -> rabbitMQConsumer.handler(rabbitMQMessage -> {
+              byte[] value = rabbitMQMessage.body().getBytes();
+              String decodedValue = decode(value, String.class);
+              LOGGER.debug("Received value {} of type {} on RabbitMQ message queue for exchange {}"
+                      , decodedValue
+                      , String.class.getName()
+                      , TEST_EXCHANGE
+              );
+              processor.accept(decodedValue);
+            }))
+            .map(rabbitMQConsumer -> rabbitMQConsumer
+            .exceptionHandler(t -> LOGGER.warn("Exception in RabbitMQ consumer", t)))
+            .map(rabbitMQConsumer -> rabbitMQClient)
+            .onSuccess(rabbitMQConsumer -> LOGGER.debug("Registered RabbitMQ message consumer for exchange {}", TEST_EXCHANGE));
+  }
+
+  private RabbitMQOptions getRabbitMQOptions() {
+    RabbitMQOptions options = new RabbitMQOptions();
+
+    ToxiproxyContainer.ContainerProxy proxy = toxiproxy.getProxy(networkedRabbitmq, 5672);
+    options.setHost(proxy.getContainerIpAddress());
+    options.setPort(proxy.getProxyPort());
+    options.setConnectionTimeout(1000);
+    options.setNetworkRecoveryInterval(1000);
+    options.setRequestedHeartbeat(1);
+    // Enable Java RabbitMQ client library reconnections
+    options.setAutomaticRecoveryEnabled(true);
+    // Disable vertx RabbitMQClient reconnections
+    options.setReconnectAttempts(0);
+    return options;
+  }
+
+  public byte[] encode(Object o) {
+    try {
+      return mapper.writeValueAsBytes(o);
+    } catch (Exception e) {
+      throw new EncodeException(e.getMessage());
     }
+  }
 
-        
-    @Before
-    public void setup() {
-      LOGGER.info("Starting");
-      this.networkedRabbitmq.start();
-      this.toxiproxy.start();
+  public <T> T decode(byte[] bytes, Class<T> type) {
+    try {
+      return mapper.readValue(bytes, type);
+    } catch (Exception e) {
+      throw new DecodeException("Failed to decode: " + e.getMessage());
     }
-    
-    @After
-    public void shutdown() {
-      this.networkedRabbitmq.stop();
-      this.toxiproxy.stop();
-      LOGGER.info("Shutdown");
-    }
-    
-    
-    @Test(timeout = 1*60*1000L)
-    public void testRecoverConnectionOutage(TestContext ctx) throws Exception {
-        Vertx vertx = Vertx.vertx();
-        createAndStartProducer(vertx);
-
-        Async async = ctx.async();
-        Handler<AsyncResult<String>> secondMessageHandler = result1 -> {
-            LOGGER.info("Got another message. Connection recovery was successful.");
-            vertx.cancelTimer(producerTimeReference.get());
-            producerReference.get().close();
-            consumerReference.get().stop();
-            async.complete();
-        };
-
-        Handler<AsyncResult<String>> firstMessageHandler = ar -> {
-            vertx.executeBlocking(f -> {
-                LOGGER.info("Got a message, Shutdown rabbitmq.");
-                networkedRabbitmq.stop();
-                f.complete();
-            }).compose(a -> {
-                return vertx.executeBlocking(f -> {
-                    LOGGER.info("Restore RabbitMQ and wait for one more message.");
-                    networkedRabbitmq.start();
-                    handlerReference.set(secondMessageHandler);
-                });
-            });
-        };
-
-        handlerReference.set(firstMessageHandler);
-
-        Consumer<String> messageProcessor = message -> {
-            assertEquals(TEST_MESSAGE, message);
-            LOGGER.warn("Received message: {}", message);
-            handlerReference.get().handle(Future.succeededFuture());
-        };
-
-
-        createAndStartConsumer(vertx, consumerReference, messageProcessor);
-
-        LOGGER.info("Await message from rabbitmq.");
-
-    }
-
-    private void createAndStartProducer(Vertx vertx) {
-
-        RabbitMQOptions options = getRabbitMQOptions();
-
-        RabbitMQClient rabbitMQClient = RabbitMQClient.create(vertx, options);
-        RabbitMQMessageProducer rabbitMQMessageProducer = new RabbitMQMessageProducer(rabbitMQClient, TEST_EXCHANGE);
-        rabbitMQMessageProducer.setUp()
-                .onFailure(ex -> LOGGER.error("Failed to start consumer: ", ex))
-                .onSuccess(v -> {
-                  LOGGER.info("Setting up periodic send");
-                  vertx.setPeriodic(1000, unused -> rabbitMQMessageProducer.send(TEST_MESSAGE));
-                  producerReference.set(rabbitMQMessageProducer);
-                }
-        );
-
-    }
-
-    private void createAndStartConsumer(Vertx vertx, AtomicReference<RabbitMQClient> consumerReference, Consumer<String> messageProcessor) {
-        createConsumer(vertx, messageProcessor)
-                .onSuccess(consumerReference::set)
-                .onFailure(ex -> LOGGER.error("Failed to start consumer: ", ex))
-                ;
-    }
-
-    private <T> Future<RabbitMQClient> createConsumer(Vertx vertx, Consumer<String> processor) {
-        LOGGER.info("Registering RabbitMQ message consumer for exchange {}...", TEST_EXCHANGE);
-        RabbitMQOptions rabbitMQOptions = getRabbitMQOptions();
-        RabbitMQClient rabbitMQClient = RabbitMQClient.create(vertx, rabbitMQOptions);
-        boolean durable = DEFAULT_RABBITMQ_EXCHANGE_DURABLE;
-        boolean autoDelete = DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE;
-        boolean exclusive = DEFAULT_RABBITMQ_EXCHANGE_EXCLUSIVE;
-        return rabbitMQClient.start()
-                .compose(aVoid -> {
-                  LOGGER.info("Consumer client started");
-                  return rabbitMQClient.exchangeDeclare(TEST_EXCHANGE
-                        , DEFAULT_RABBITMQ_EXCHANGE_TYPE
-                        , DEFAULT_RABBITMQ_EXCHANGE_DURABLE
-                        , DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE);
-                })
-                .compose(aVoid -> {
-                  LOGGER.info("Exchange declared by consumer");
-                  return rabbitMQClient.queueDeclare(TEST_QUEUE, durable, exclusive, autoDelete);
-                })
-                .compose(declareResult -> {
-                  LOGGER.info("Queue declared by consumer");
-                  return rabbitMQClient.queueBind(TEST_QUEUE, TEST_EXCHANGE, "");
-                })
-                .compose(aVoid -> {
-                  LOGGER.info("Queue bound to exchange");
-                  return rabbitMQClient.basicConsumer(TEST_QUEUE);
-                })
-                .map(rabbitMQConsumer -> rabbitMQConsumer.handler(rabbitMQMessage -> {
-                    byte[] value = rabbitMQMessage.body().getBytes();
-                    String decodedValue = decode(value, String.class);
-                    LOGGER.debug("Received value {} of type {} on RabbitMQ message queue for exchange {}",
-                            decodedValue,
-                            String.class.getName(),
-                            TEST_EXCHANGE);
-                    processor.accept(decodedValue);
-                }))
-                .map(rabbitMQConsumer -> rabbitMQConsumer
-                        .exceptionHandler(t -> LOGGER.warn("Exception in RabbitMQ consumer", t)))
-                .map(rabbitMQConsumer -> rabbitMQClient)
-                .onSuccess(rabbitMQConsumer -> LOGGER.debug("Registered RabbitMQ message consumer for exchange {}", TEST_EXCHANGE));
-    }
-
-    private RabbitMQOptions getRabbitMQOptions() {
-        RabbitMQOptions options = new RabbitMQOptions();
-
-        ToxiproxyContainer.ContainerProxy proxy = toxiproxy.getProxy(networkedRabbitmq, 5672);
-        options.setHost(proxy.getContainerIpAddress());
-        options.setPort(proxy.getProxyPort());
-        options.setConnectionTimeout(1000);
-        options.setNetworkRecoveryInterval(1000);
-        options.setRequestedHeartbeat(1);
-        // Enable Java RabbitMQ client library reconnections
-        options.setAutomaticRecoveryEnabled(true);
-        // Diable vertx RabbitMQClient reconnections
-        options.setReconnectAttempts(0);
-        return options;
-    }
-
-    public byte[] encode(Object o) {
-        try {
-            return mapper.writeValueAsBytes(o);
-        } catch (Exception e) {
-            throw new EncodeException(e.getMessage());
-        }
-    }
-    
-    public <T> T decode(byte[] bytes, Class<T> type) {
-        try {
-            return mapper.readValue(bytes, type);
-        } catch (Exception e) {
-            throw new DecodeException("Failed to decode: " + e.getMessage());
-        }
-    }
+  }
 }

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientBuiltInReconnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientBuiltInReconnectTest.java
@@ -1,0 +1,307 @@
+package io.vertx.rabbitmq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.EncodeException;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static com.rabbitmq.client.BuiltinExchangeType.FANOUT;
+import static org.junit.Assert.assertEquals;
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/**
+ *
+ * @author jtalbut
+ */
+@RunWith(VertxUnitRunner.class)
+public class RabbitMQClientBuiltInReconnectTest {
+  
+  /**
+   * This test verifies that the RabbitMQ Java client reconnection logic works 
+   * as long as the vertx reconnect attempts is set to zero.
+   * 
+   * The change that makes this work is in the basicConsumer, where the shutdown handler
+   * is only set if retries > 0.
+   * Without that change the vertx client shutdown handler is called, interrupting the java
+   * client reconnection logic, even though the vertx reconnection won't work because retries is zero.
+   * 
+   */
+  
+    private static final String TEST_EXCHANGE = "RabbitMQClientBuiltInReconnectExchange";
+    private static final String TEST_QUEUE = "RabbitMQClientBuiltInReconnectQueue";
+    private static final String TEST_MESSAGE = "My Message";
+    private static final boolean DEFAULT_RABBITMQ_EXCHANGE_DURABLE = false;
+    private static final boolean DEFAULT_RABBITMQ_EXCHANGE_EXCLUSIVE = true;
+    private static final boolean DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE = true;
+    private static final String DEFAULT_RABBITMQ_EXCHANGE_TYPE = FANOUT.getType();
+  
+    public class RabbitMQMessageProducer {
+
+        private final RabbitMQClient rabbitMQClient;
+
+        private final String topic;
+
+        public RabbitMQMessageProducer(RabbitMQClient rabbitMQClient, String topic) {
+            this.rabbitMQClient = rabbitMQClient;
+            this.topic = topic;
+        }
+
+        public Future<Void> setUp() {
+            return rabbitMQClient.start()
+                    .compose(aVoid -> rabbitMQClient.exchangeDeclare(topic, 
+                            DEFAULT_RABBITMQ_EXCHANGE_TYPE,
+                            DEFAULT_RABBITMQ_EXCHANGE_DURABLE,
+                            DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE))
+                    .onSuccess(result -> {
+                        LOGGER.info("Created exchange '{}': {}", topic, result);
+                    })
+                    .compose(aVoid -> rabbitMQClient.confirmSelect())
+                    .onSuccess(result -> LOGGER.info("Confirmation enabled for topic {}", topic))
+                    .onFailure(throwable -> LOGGER.warn("Failed to create exchange '{}'", topic, throwable))
+                    ;
+        }
+
+        public void send(String message) {
+            LOGGER.info("Sending message {} to RabbitMQ topic {}", message, topic);
+            byte[] messageAsBytes = encode(message);
+
+            rabbitMQClient
+                    .basicPublish(topic, "", Buffer.buffer(messageAsBytes))
+                    .compose(aVoid -> rabbitMQClient.waitForConfirms(60000))
+                    .onSuccess(aVoid -> LOGGER.debug("Published message {} to RabbitMQ topic {}", message, topic))
+                    .onFailure(throwable -> LOGGER.warn("Failed to publish message {} to RabbitMQ topic {}", message, topic, throwable))
+                    ;
+        }
+
+        public Future<Void> close() {
+            return rabbitMQClient.stop();
+        }
+    }
+  
+    public static class RabbitMqConsumer {
+        private RabbitMQClient client;
+
+        public RabbitMqConsumer(Vertx vertx) {
+            RabbitMQOptions config = new RabbitMQOptions();
+            client = RabbitMQClient.create(vertx, config);
+        }
+
+        public void listen() {
+
+            // Connect
+            client.start(asyncResult -> {
+                if (asyncResult.succeeded()) {
+                    System.out.println("RabbitMQ successfully connected!");
+                } else {
+                    System.out.println("Fail to connect to RabbitMQ " + asyncResult.cause().getMessage());
+                }
+            });
+        }
+    }
+  
+  
+    private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQClientBuiltInReconnectTest.class);
+
+    AtomicLong producerTimeReference = new AtomicLong();
+    AtomicReference<RabbitMQMessageProducer> producerReference = new AtomicReference<>();
+    AtomicReference<RabbitMQClient> consumerReference = new AtomicReference<>();
+    AtomicReference<Handler<AsyncResult<String>>> handlerReference = new AtomicReference<>();
+
+    private final ObjectMapper mapper;
+    private final Network network;
+    private final GenericContainer networkedRabbitmq;
+    private final ToxiproxyContainer toxiproxy;
+
+    public RabbitMQClientBuiltInReconnectTest() {
+      LOGGER.info("Constructing");
+      this.mapper =  new ObjectMapper();
+      this.network = Network.newNetwork();
+      this.networkedRabbitmq = new GenericContainer(DockerImageName.parse("rabbitmq:3.8.6-alpine"))
+            .withExposedPorts(5672)
+            .withNetwork(network);
+      this.toxiproxy = new ToxiproxyContainer(DockerImageName.parse("shopify/toxiproxy:2.1.0"))
+            .withNetwork(network);
+    }
+
+        
+    @Before
+    public void setup() {
+      LOGGER.info("Starting");
+      this.networkedRabbitmq.start();
+      this.toxiproxy.start();
+    }
+    
+    @After
+    public void shutdown() {
+      this.networkedRabbitmq.stop();
+      this.toxiproxy.stop();
+      LOGGER.info("Shutdown");
+    }
+    
+    
+    @Test(timeout = 1*60*1000L)
+    public void testRecoverConnectionOutage(TestContext ctx) throws Exception {
+        Vertx vertx = Vertx.vertx();
+        createAndStartProducer(vertx);
+
+        Async async = ctx.async();
+        Handler<AsyncResult<String>> secondMessageHandler = result1 -> {
+            LOGGER.info("Got another message. Connection recovery was successful.");
+            vertx.cancelTimer(producerTimeReference.get());
+            producerReference.get().close();
+            consumerReference.get().stop();
+            async.complete();
+        };
+
+        Handler<AsyncResult<String>> firstMessageHandler = ar -> {
+            vertx.executeBlocking(f -> {
+                LOGGER.info("Got a message, Shutdown rabbitmq.");
+                networkedRabbitmq.stop();
+                f.complete();
+            }).compose(a -> {
+                return vertx.executeBlocking(f -> {
+                    LOGGER.info("Restore RabbitMQ and wait for one more message.");
+                    networkedRabbitmq.start();
+                    handlerReference.set(secondMessageHandler);
+                });
+            });
+        };
+
+        handlerReference.set(firstMessageHandler);
+
+        Consumer<String> messageProcessor = message -> {
+            assertEquals(TEST_MESSAGE, message);
+            LOGGER.warn("Received message: {}", message);
+            handlerReference.get().handle(Future.succeededFuture());
+        };
+
+
+        createAndStartConsumer(vertx, consumerReference, messageProcessor);
+
+        LOGGER.info("Await message from rabbitmq.");
+
+    }
+
+    private void createAndStartProducer(Vertx vertx) {
+
+        RabbitMQOptions options = getRabbitMQOptions();
+
+        RabbitMQClient rabbitMQClient = RabbitMQClient.create(vertx, options);
+        RabbitMQMessageProducer rabbitMQMessageProducer = new RabbitMQMessageProducer(rabbitMQClient, TEST_EXCHANGE);
+        rabbitMQMessageProducer.setUp()
+                .onFailure(ex -> LOGGER.error("Failed to start consumer: ", ex))
+                .onSuccess(v -> {
+                  LOGGER.info("Setting up periodic send");
+                  vertx.setPeriodic(1000, unused -> rabbitMQMessageProducer.send(TEST_MESSAGE));
+                  producerReference.set(rabbitMQMessageProducer);
+                }
+        );
+
+    }
+
+    private void createAndStartConsumer(Vertx vertx, AtomicReference<RabbitMQClient> consumerReference, Consumer<String> messageProcessor) {
+        createConsumer(vertx, messageProcessor)
+                .onSuccess(consumerReference::set)
+                .onFailure(ex -> LOGGER.error("Failed to start consumer: ", ex))
+                ;
+    }
+
+    private <T> Future<RabbitMQClient> createConsumer(Vertx vertx, Consumer<String> processor) {
+        LOGGER.info("Registering RabbitMQ message consumer for exchange {}...", TEST_EXCHANGE);
+        RabbitMQOptions rabbitMQOptions = getRabbitMQOptions();
+        RabbitMQClient rabbitMQClient = RabbitMQClient.create(vertx, rabbitMQOptions);
+        boolean durable = DEFAULT_RABBITMQ_EXCHANGE_DURABLE;
+        boolean autoDelete = DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE;
+        boolean exclusive = DEFAULT_RABBITMQ_EXCHANGE_EXCLUSIVE;
+        return rabbitMQClient.start()
+                .compose(aVoid -> {
+                  LOGGER.info("Consumer client started");
+                  return rabbitMQClient.exchangeDeclare(TEST_EXCHANGE
+                        , DEFAULT_RABBITMQ_EXCHANGE_TYPE
+                        , DEFAULT_RABBITMQ_EXCHANGE_DURABLE
+                        , DEFAULT_RABBITMQ_EXCHANGE_AUTO_DELETE);
+                })
+                .compose(aVoid -> {
+                  LOGGER.info("Exchange declared by consumer");
+                  return rabbitMQClient.queueDeclare(TEST_QUEUE, durable, exclusive, autoDelete);
+                })
+                .compose(declareResult -> {
+                  LOGGER.info("Queue declared by consumer");
+                  return rabbitMQClient.queueBind(TEST_QUEUE, TEST_EXCHANGE, "");
+                })
+                .compose(aVoid -> {
+                  LOGGER.info("Queue bound to exchange");
+                  return rabbitMQClient.basicConsumer(TEST_QUEUE);
+                })
+                .map(rabbitMQConsumer -> rabbitMQConsumer.handler(rabbitMQMessage -> {
+                    byte[] value = rabbitMQMessage.body().getBytes();
+                    String decodedValue = decode(value, String.class);
+                    LOGGER.debug("Received value {} of type {} on RabbitMQ message queue for exchange {}",
+                            decodedValue,
+                            String.class.getName(),
+                            TEST_EXCHANGE);
+                    processor.accept(decodedValue);
+                }))
+                .map(rabbitMQConsumer -> rabbitMQConsumer
+                        .exceptionHandler(t -> LOGGER.warn("Exception in RabbitMQ consumer", t)))
+                .map(rabbitMQConsumer -> rabbitMQClient)
+                .onSuccess(rabbitMQConsumer -> LOGGER.debug("Registered RabbitMQ message consumer for exchange {}", TEST_EXCHANGE));
+    }
+
+    private RabbitMQOptions getRabbitMQOptions() {
+        RabbitMQOptions options = new RabbitMQOptions();
+
+        ToxiproxyContainer.ContainerProxy proxy = toxiproxy.getProxy(networkedRabbitmq, 5672);
+        options.setHost(proxy.getContainerIpAddress());
+        options.setPort(proxy.getProxyPort());
+        options.setConnectionTimeout(1000);
+        options.setNetworkRecoveryInterval(1000);
+        options.setRequestedHeartbeat(1);
+        // Enable Java RabbitMQ client library reconnections
+        options.setAutomaticRecoveryEnabled(true);
+        // Diable vertx RabbitMQClient reconnections
+        options.setReconnectAttempts(0);
+        return options;
+    }
+
+    public byte[] encode(Object o) {
+        try {
+            return mapper.writeValueAsBytes(o);
+        } catch (Exception e) {
+            throw new EncodeException(e.getMessage());
+        }
+    }
+    
+    public <T> T decode(byte[] bytes, Class<T> type) {
+        try {
+            return mapper.readValue(bytes, type);
+        } catch (Exception e) {
+            throw new DecodeException("Failed to decode: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Redo PR because the other got lost in the build failures

Motivation:

Versions 4.0.0-4.0.2 have a regression that prevents the use of the Java rabbitmq client reconnections.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
