### PR TITLE
[3.9] Allow to set a name for connections

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -38,6 +38,7 @@
 |[[automaticRecoveryEnabled]]`@automaticRecoveryEnabled`|`Boolean`|+++
 Enables or disables automatic connection recovery.
 +++
+|[[connectionName]]`@connectionName`|`String`|-
 |[[connectionRetries]]`@connectionRetries`|`Number (Integer)`|+++
 Set the number of connection retries to attempt when connecting, the <code>null</code> value disables it.
 +++

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -81,6 +81,11 @@ public class RabbitMQOptions {
    * The default connection retries = {@code null} (no retry)
    */
   public static final Integer DEFAULT_CONNECTION_RETRIES = null;
+  
+  /**
+   * The default connection name = {@code VertxRabbitMQ}
+   */
+  public static final String DEFAULT_CONNECTION_NAME = "VertxRabbitMQ";
 
   private Integer connectionRetries = DEFAULT_CONNECTION_RETRIES;
   private long connectionRetryDelay = DEFAULT_CONNECTION_RETRY_DELAY;
@@ -98,6 +103,7 @@ public class RabbitMQOptions {
   private long networkRecoveryInterval = DEFAULT_NETWORK_RECOVERY_INTERNAL;
   private boolean automaticRecoveryEnabled = DEFAULT_AUTOMATIC_RECOVERY_ENABLED;
   private boolean includeProperties = false;
+  private String connectionName = DEFAULT_CONNECTION_NAME;
 
   public RabbitMQOptions() {
   }
@@ -124,6 +130,7 @@ public class RabbitMQOptions {
     automaticRecoveryEnabled = that.automaticRecoveryEnabled;
     includeProperties = that.includeProperties;
     requestedChannelMax = that.requestedChannelMax;
+    connectionName = that.connectionName;
   }
 
   /**
@@ -398,6 +405,15 @@ public class RabbitMQOptions {
    */
   public RabbitMQOptions setIncludeProperties(boolean includeProperties) {
     this.includeProperties = includeProperties;
+    return this;
+  }
+
+  public String getConnectionName() {
+    return connectionName;
+  }
+
+  public RabbitMQOptions setConnectionName(String connectionName) {
+    this.connectionName = connectionName;
     return this;
   }
 }

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -76,8 +76,8 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     //TODO: Support other configurations
 
     return addresses == null
-           ? cf.newConnection()
-           : cf.newConnection(addresses);
+           ? cf.newConnection(config.getConnectionName())
+           : cf.newConnection(addresses, config.getConnectionName());
   }
 
   @Override

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQOptionsTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQOptionsTest.java
@@ -31,6 +31,8 @@ public class RabbitMQOptionsTest {
     int expectedConnectionRetryDelay = TestUtils.randomPositiveInt();
     Integer expectedConnectionRetries = TestUtils.randomBoolean() ? TestUtils.randomPositiveInt() : null;
     boolean expectedIncludeProperties = TestUtils.randomBoolean();
+    String connectionName = TestUtils.randomAlphaString(20);
+
     JsonObject json = new JsonObject();
     json.put("uri", expectedUri);
     json.put("user", expectedUser);
@@ -47,6 +49,7 @@ public class RabbitMQOptionsTest {
     json.put("connectionRetryDelay", expectedConnectionRetryDelay);
     json.put("connectionRetries", expectedConnectionRetries);
     json.put("includeProperties", expectedIncludeProperties);
+    json.put("connectionName", connectionName);
     RabbitMQOptions options = new RabbitMQOptions();
     assertSame(options, options.setUri(expectedUri));
     assertSame(options, options.setUser(expectedUser));
@@ -63,6 +66,8 @@ public class RabbitMQOptionsTest {
     assertSame(options, options.setConnectionRetryDelay(expectedConnectionRetryDelay));
     assertSame(options, options.setConnectionRetries(expectedConnectionRetries));
     assertSame(options, options.setIncludeProperties(expectedIncludeProperties));
+    assertSame(options, options.setConnectionName(connectionName));
+
     for (RabbitMQOptions testOptions : Arrays.asList(new RabbitMQOptions(json), new RabbitMQOptions(options))) {
       assertEquals(testOptions.getUri(), expectedUri);
       assertEquals(testOptions.getUser(), expectedUser);
@@ -79,6 +84,7 @@ public class RabbitMQOptionsTest {
       assertEquals(testOptions.getConnectionRetryDelay(), expectedConnectionRetryDelay);
       assertEquals(testOptions.getConnectionRetries(), expectedConnectionRetries);
       assertEquals(testOptions.getIncludeProperties(), expectedIncludeProperties);
-    }
+      assertEquals(testOptions.getConnectionName(), connectionName);
+     }
   }
 }


### PR DESCRIPTION
references #130

Same as #131 but on branch 3.9 (from what I've seen src/main/generated is not committed on 3.9, contrary to 4.x - but correct me if I'm wrong, and I'll push the 2 Converters classes)