### PR TITLE
Fix bug: Some consumers using the same client may Failed to manualAck, after automatic reconnection.

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQClient.java
@@ -585,7 +585,12 @@ public interface RabbitMQClient {
    * @see com.rabbitmq.client.ShutdownNotifier#isOpen()
    */
   boolean isConnected();
-
+  /***
+   * restart the rabbitMQ connect.
+   * @param attempts  number of attempts
+   * @param resultHandler handler called when operation is done with a result of the operation
+   */
+  void restartConnect(int attempts, Handler<AsyncResult<Void>> resultHandler);
   /**
    * Check if a channel is open
    *

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Address;
@@ -22,6 +23,7 @@ import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
 
+import com.rabbitmq.client.impl.AMQImpl;
 import io.netty.handler.ssl.JdkSslContext;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
@@ -52,7 +54,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
   private static final Logger log = LoggerFactory.getLogger(RabbitMQClientImpl.class);
   private static final JsonObject emptyConfig = new JsonObject();
-  
+
   private final Vertx vertx;
   private final RabbitMQOptions config;
   private final int retries;
@@ -62,7 +64,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
   private long channelInstance;
   private boolean channelConfirms = false;
   private boolean hasConnected = false;
-  
+  private AtomicBoolean isReconnecting = new AtomicBoolean(false);
   private List<Handler<Promise<Void>>> connectionEstablishedCallbacks = new ArrayList<>();
 
   public RabbitMQClientImpl(Vertx vertx, RabbitMQOptions config) {
@@ -74,15 +76,15 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
   public long getChannelInstance() {
     return channelInstance;
   }
-  
+
   @Override
   public void addConnectionEstablishedCallback(Handler<Promise<Void>> connectionEstablishedCallback) {
     this.connectionEstablishedCallbacks.add(connectionEstablishedCallback);
   }
-  
+
   private static Connection newConnection(Vertx vertx, RabbitMQOptions config) throws IOException, TimeoutException {
     ConnectionFactory cf = new ConnectionFactory();
-    
+
     String uri = config.getUri();
     // Use uri if set, otherwise support individual connection parameters
     List<Address> addresses = null;
@@ -97,8 +99,8 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       cf.setUsername(config.getUser());
       cf.setPassword(config.getPassword());
       addresses = config.getAddresses().isEmpty()
-                  ? Collections.singletonList(new Address(config.getHost(), config.getPort()))
-                  : config.getAddresses();
+        ? Collections.singletonList(new Address(config.getHost(), config.getPort()))
+        : config.getAddresses();
       cf.setVirtualHost(config.getVirtualHost());
     }
 
@@ -109,11 +111,11 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     cf.setNetworkRecoveryInterval(config.getNetworkRecoveryInterval());
     cf.setAutomaticRecoveryEnabled(config.isAutomaticRecoveryEnabled());
 
-    if(config.isSsl()) {  
-    	//The RabbitMQ Client connection needs a JDK SSLContext, so force this setting.
-    	config.setSslEngineOptions(new JdkSSLEngineOptions());
-    	SSLHelper sslHelper = new SSLHelper(config, config.getKeyCertOptions(), config.getTrustOptions());
-    	JdkSslContext ctx = (JdkSslContext)sslHelper.getContext((VertxInternal)vertx);
+    if (config.isSsl()) {
+      //The RabbitMQ Client connection needs a JDK SSLContext, so force this setting.
+      config.setSslEngineOptions(new JdkSSLEngineOptions());
+      SSLHelper sslHelper = new SSLHelper(config, config.getKeyCertOptions(), config.getTrustOptions());
+      JdkSslContext ctx = (JdkSslContext) sslHelper.getContext((VertxInternal) vertx);
       cf.useSslProtocol(ctx.context());
     }
 
@@ -124,8 +126,8 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     //TODO: Support other configurations
 
     return addresses == null
-           ? cf.newConnection()
-           : cf.newConnection(addresses);
+      ? cf.newConnection()
+      : cf.newConnection(addresses);
   }
 
   @Override
@@ -177,45 +179,91 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
   }
 
   private void restartConsumer(int attempts, QueueConsumerHandler handler, QueueOptions options) {
+    if (handler.queue().isCancelled()) {
+      return;
+    }
+    restartConnect(0, rh -> {
+      forChannel(chan -> {
+        RabbitMQConsumer q = handler.queue();
+        chan.basicConsume(q.queueName(), options.isAutoAck(), handler);
+        log.info("Reconsume queue: " + q.queueName() + " success");
+        return q.resume();
+      }).onComplete(arChan -> {
+        if (arChan.failed()) {
+          log.error("Failed to restart consumer: ", arChan.cause());
+          long delay = config.getReconnectInterval();
+          vertx.setTimer(delay, id -> {
+            restartConsumer(attempts + 1, handler, options);
+          });
+        }
+      });
+    });
+
+  }
+
+  /***
+   * Restore connection and channel. Both queue consumers and producers call this method. To avoid repeated creation and overwriting of connections and channel, CAS-Lock are used here
+   * @param attempts  number of attempts
+   * @param resultHandler handler called when operation is done with a result of the operation
+   */
+  public void restartConnect(int attempts, Handler<AsyncResult<Void>> resultHandler) {
+    if (isReconnecting.compareAndSet(false, true)) {
+      if (channel != null && channel.isOpen()) {
+        log.debug("Other consumers or producers reconnect successfully. Reuse their channel");
+        resultHandler.handle(Future.succeededFuture());
+        isReconnecting.set(false);
+        return;
+      }
+      log.debug("Start to reconnect...");
+      execRestart(attempts, resultHandler);
+      return;
+
+    }
+
+    log.debug("Other consumers or producers are reconnecting. Continue to wait for reconnection");
+    vertx.setTimer(config.getReconnectInterval(), id -> {
+      restartConnect(attempts, resultHandler);
+    });
+    return;
+
+  }
+
+  private void execRestart(int attempts, Handler<AsyncResult<Void>> resultHandler) {
     stop(ar -> {
-      if (!handler.queue().isCancelled()) {
-        if (ar.succeeded()) {    
-          if (retries == 0) {
-            log.error("Retries disabled. Will not attempt to restart");
-          } else if (attempts >= retries) {
-            log.error("Max number of consumer restart attempts (" + retries + ") reached. Will not attempt to restart again");
-          } else {
-            start((arStart) -> {
-              if (arStart.succeeded()) {
-                forChannel(chan -> {
-                  RabbitMQConsumer q = handler.queue();
-                  chan.basicConsume(q.queueName(), options.isAutoAck(), handler);
-                  return q.resume();
-                }).onComplete(arChan -> {
-                  if (arChan.failed()) {
-                    log.error("Failed to restart consumer: ", arChan.cause());
-                    long delay = config.getReconnectInterval();
-                    vertx.setTimer(delay, id -> {
-                      restartConsumer(attempts + 1, handler, options);
-                    });
-                  }
-                });
+      if (ar.succeeded()) {
+        if (retries == 0) {
+          log.error("Retries disabled. Will not attempt to restart");
+        } else if (attempts >= retries) {
+          log.error("Max number of consumer restart attempts (" + retries + ") reached. Will not attempt to restart again");
+        } else {
+          start((arStart) -> {
+            if (arStart.succeeded()) {
+              if (channelConfirms) {
+                //Restore confirmSelect
+                confirmSelect();
+              }
+              log.info("Successed to restart client. ");
+              isReconnecting.set(false);
+              resultHandler.handle(arStart);
             } else {
               log.error("Failed to restart client: ", arStart.cause());
               long delay = config.getReconnectInterval();
               vertx.setTimer(delay, id -> {
-                restartConsumer(attempts + 1, handler, options);
+                execRestart(attempts + 1, resultHandler);
               });
             }
           });
-          }
-        } else {
-          log.error("Failed to stop client, will not attempt to restart: ", ar.cause());
         }
+      } else {
+        log.error("Failed to stop client, will attempt to restart: ", ar.cause());
+        vertx.setTimer(config.getReconnectInterval(), id -> {
+          execRestart(attempts + 1, resultHandler);
+        });
       }
-    });    
+
+    });
   }
-  
+
   @Override
   public void basicConsumer(String queue, QueueOptions options, Handler<AsyncResult<RabbitMQConsumer>> resultHandler) {
     Future<RabbitMQConsumer> fut = basicConsumer(queue, options);
@@ -236,7 +284,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       }
       try {
         channel.basicConsume(queue, options.isAutoAck(), handler);
-      } catch(Throwable ex) {
+      } catch (Throwable ex) {
         log.warn("Failed to consume: ", ex);
         restartConsumer(0, handler, options);
       }
@@ -249,8 +297,8 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       // Deliver to the application
       return q;
     });
-  }  
-  
+  }
+
   @Override
   public void basicGet(String queue, boolean autoAck, Handler<AsyncResult<RabbitMQMessage>> resultHandler) {
     Future<RabbitMQMessage> fut = basicGet(queue, autoAck);
@@ -280,12 +328,12 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
   public Future<Void> basicPublish(String exchange, String routingKey, Buffer body) {
     return basicPublishWithDeliveryTag(exchange, routingKey, new AMQP.BasicProperties(), body, null);
   }
-  
+
   @Override
   public void basicPublish(String exchange, String routingKey, BasicProperties properties, Buffer body, Handler<AsyncResult<Void>> resultHandler) {
     basicPublishWithDeliveryTag(exchange, routingKey, properties, body, null, resultHandler);
   }
-    
+
   @Override
   public Future<Void> basicPublish(String exchange, String routingKey, BasicProperties properties, Buffer body) {
     return basicPublishWithDeliveryTag(exchange, routingKey, properties, body, null);
@@ -298,7 +346,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       fut.onComplete(resultHandler);
     }
   }
-  
+
   @Override
   public Future<Void> basicPublishWithDeliveryTag(String exchange, String routingKey, BasicProperties properties, Buffer body, @Nullable Handler<Long> deliveryTagHandler) {
     return forChannel(channel -> {
@@ -310,7 +358,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       return null;
     });
   }
-  
+
   @Override
   public void addConfirmListener(int maxQueueSize, Handler<AsyncResult<ReadStream<RabbitMQConfirmation>>> resultHandler) {
     Future<ReadStream<RabbitMQConfirmation>> fut = addConfirmListener(maxQueueSize);
@@ -332,7 +380,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       return handler.getListener();
     });
   }
-  
+
   @Override
   public void confirmSelect(Handler<AsyncResult<Void>> resultHandler) {
     Future<Void> fut = confirmSelect();
@@ -730,7 +778,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
         ++channelInstance;
         channel = connection.createChannel();
 
-        if(channelConfirms)
+        if (channelConfirms)
           channel.confirmSelect();
       } catch (IOException e) {
         log.debug("create channel error");
@@ -770,7 +818,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       if (prevResult.failed()) {
         connectPromise.fail(prevResult.cause());
       } else {
-        if (iter.hasNext()) {        
+        if (iter.hasNext()) {
           Handler<Promise<Void>> next = iter.next();
           Promise<Void> callbackPromise = Promise.promise();
           next.handle(callbackPromise);
@@ -779,7 +827,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
           connectPromise.complete();
         }
       }
-    } catch(Throwable ex) {
+    } catch (Throwable ex) {
       log.error("Exception whilst running connection stablished callback: ", ex);
       connectPromise.fail(ex);
     }
@@ -793,7 +841,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
         connection.close();
       }
       log.debug("Disconnected from rabbitmq !");
-    } catch(AlreadyClosedException ex) {
+    } catch (AlreadyClosedException ex) {
       log.debug("Already disconnected from rabbitmq !");
     } finally {
       connection = null;
@@ -807,9 +855,13 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       return;
     }
     log.info("RabbitMQ connection shutdown! The client will attempt to reconnect automatically", cause);
+    //Make sure to perform reconnection
+    restartConnect(0, rh -> {
+      log.info("reconnect success");
+    });
   }
 
   private interface ChannelHandler<T> {
     T handle(Channel channel) throws Exception;
-  }  
+  }
 }

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java
@@ -41,26 +41,26 @@ import java.util.Iterator;
  * @author jtalbut
  */
 public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<RabbitMQPublisherConfirmation> {
-  
+
   private static final Logger log = LoggerFactory.getLogger(RabbitMQPublisherImpl.class);
-  
+
   private final Vertx vertx;
   private final RabbitMQClient client;
   private final InboundBuffer<RabbitMQPublisherConfirmation> confirmations;
   private final Context context;
   private final RabbitMQPublisherOptions options;
-  
+
   private final Deque<MessageDetails> pendingAcks = new ArrayDeque<>();
   private final InboundBuffer<MessageDetails> sendQueue;
   private long lastChannelInstance = 0;
   private volatile boolean stopped = false;
-  
+
   /**
    * POD for holding message details pending acknowledgement.
    * @param <I> The type of the message IDs.
    */
   static class MessageDetails {
-  
+
     private final String exchange;
     private final String routingKey;
     private final BasicProperties properties;
@@ -79,9 +79,9 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     public void setDeliveryTag(long deliveryTag) {
       this.deliveryTag = deliveryTag;
     }
-    
+
   }
-  
+
   public RabbitMQPublisherImpl(Vertx vertx
           , RabbitMQClient client
           , RabbitMQPublisherOptions options
@@ -138,17 +138,17 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     sendQueue.emptyHandler(null);
     sendQueue.resume();
   }
-  
+
   private Promise<Void> startForPromise() {
     Promise<Void> promise = Promise.promise();
     addConfirmListener(client, options, promise);
     return promise;
   }
-  
+
   protected final void addConfirmListener(RabbitMQClient client1
           , RabbitMQPublisherOptions options1
           , Promise<Void> promise
-  ) {    
+  ) {
     client1.addConfirmListener(options1.getMaxInternalQueueSize(),
             ar -> {
               if (ar.succeeded()) {
@@ -172,13 +172,13 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
   public int queueSize() {
     return sendQueue.size();
   }
-  
+
   private void handleMessageSend(MessageDetails md) {
     sendQueue.pause();
     synchronized(pendingAcks) {
       pendingAcks.add(md);
     }
-    doSend(md);    
+    doSend(md);
   }
 
   private void doSend(MessageDetails md) {
@@ -186,7 +186,7 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
       client.basicPublishWithDeliveryTag(md.exchange, md.routingKey, md.properties, md.message
           , dt -> { md.setDeliveryTag(dt); }
           , publishResult -> {
-            try {              
+            try {
               if (publishResult.succeeded()) {
                 if (md.publishHandler != null) {
                   try {
@@ -201,10 +201,8 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
                 synchronized(pendingAcks) {
                   pendingAcks.remove(md);
                 }
-                client.stop(v -> {
-                  client.start(v2 -> {
-                    doSend(md);
-                  });
+                client.restartConnect(0,rcRt->{
+                  doSend(md);
                 });
               }
             } finally {
@@ -214,14 +212,12 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
       synchronized(pendingAcks) {
         pendingAcks.remove(md);
       }
-      client.stop(v -> {
-        client.start(v2 -> {
-          doSend(md);
-        });
+      client.restartConnect(0,rcRt->{
+        doSend(md);
       });
     }
   }
-  
+
   private void handleConfirmation(RabbitMQConfirmation rawConfirmation) {
     synchronized(pendingAcks) {
       if (lastChannelInstance == 0) {
@@ -255,7 +251,7 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
       }
     }
   }
-  
+
   @Override
   public void publish(String exchange, String routingKey, BasicProperties properties, Buffer body, Handler<AsyncResult<Void>> resultHandler) {
     if (!stopped) {
@@ -270,8 +266,8 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     Promise<Void> promise = Promise.promise();
     publish(exchange, routingKey, properties, body, promise);
     return promise.future();
-  }  
-  
+  }
+
   @Override
   public RabbitMQPublisherImpl exceptionHandler(Handler<Throwable> hndlr) {
     confirmations.exceptionHandler(hndlr);
@@ -306,7 +302,7 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
   public RabbitMQPublisherImpl endHandler(Handler<Void> hndlr) {
     return this;
   }
-  
-  
-  
+
+
+
 }


### PR DESCRIPTION
Motivation:

I only create an instance of [RabbitMQClientImpl ](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java) class to consume two queues. After the automatic reconnection, I found two problems:
- question 1: Two connections and two channels appeared on the management page of rabbitmq.
- question 2: Only one queue can be acked manually, and the other queues fail to manually ack. The client received the following exception: 
`ShutdownSignalException: com.rabbitmq.client.ShutdownSignalException: channel error; protocol method: #method<channel.close>(reply-code=406, reply-text= PRECONDITION_FAILED-unknown delivery tag 7, class-id=60, method-id=80)`.

Reconnect configuration:
[I refer to the document for the following configuration](https://vertx.io/docs/vertx-rabbitmq-client/java/#_recovery_and_reconnections)
```
RabbitMQOptions options = new RabbitMQOptions();
options.setAutomaticRecoveryEnabled(false);
options.setReconnectAttempts(Integer.MAX_VALUE);
options.setReconnectInterval(2000);
```

Let’s analyze how they happened:
- question 1: The reason lies in the [RabbitMQClientImpl ](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java) class. The    [RabbitMQClientImpl#basicConsumer](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java#L234) method requires each queue consumer to execute the [RabbitMQClientImpl#restartConsumer ](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java#L179) method after receiving the "ShutdownSignal". If there are n queue consumers in one client, this method will be executed n times, and n connections will be created. Therefore, n connections appear on the management page.
- question 2: As mentioned above, when reconnecting, consumer A creates connection A and uses connection A to reconsume queue, then consumer B creates connection B and uses connection B to reconsume queue. Finally, connection A is overwrited by connection B in instance of [RabbitMQClientImpl ](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java) class. This causes consumer A to use connection A to get the message, but use connection B to manually ACK. So the rabbitmq service returns the above error.

Solution:
In order to fix These problems, I use CAS-Lock to avoid repeated connection creation. Whether it is a consumer or a producer who wants to initiate a reconnection, the lock must be acquired first.

Thank you for the review.
