### PR TITLE
Fix bug:The publisher unable to handle the first acknowledge message correctly after reconnection.

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java
@@ -41,26 +41,26 @@ import java.util.Iterator;
  * @author jtalbut
  */
 public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<RabbitMQPublisherConfirmation> {
-  
+
   private static final Logger log = LoggerFactory.getLogger(RabbitMQPublisherImpl.class);
-  
+
   private final Vertx vertx;
   private final RabbitMQClient client;
   private final InboundBuffer<RabbitMQPublisherConfirmation> confirmations;
   private final Context context;
   private final RabbitMQPublisherOptions options;
-  
+
   private final Deque<MessageDetails> pendingAcks = new ArrayDeque<>();
   private final InboundBuffer<MessageDetails> sendQueue;
   private long lastChannelInstance = 0;
   private volatile boolean stopped = false;
-  
+
   /**
    * POD for holding message details pending acknowledgement.
    * @param <I> The type of the message IDs.
    */
   static class MessageDetails {
-  
+
     private final String exchange;
     private final String routingKey;
     private final BasicProperties properties;
@@ -79,9 +79,9 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     public void setDeliveryTag(long deliveryTag) {
       this.deliveryTag = deliveryTag;
     }
-    
+
   }
-  
+
   public RabbitMQPublisherImpl(Vertx vertx
           , RabbitMQClient client
           , RabbitMQPublisherOptions options
@@ -95,6 +95,14 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     this.options = options;
     this.client.addConnectionEstablishedCallback(p -> {
       addConfirmListener(client, options, p);
+      if(client instanceof RabbitMQClientImpl){
+        if (lastChannelInstance == 0) {
+          lastChannelInstance = ((RabbitMQClientImpl)client).getChannelInstance();
+        } else if (lastChannelInstance != ((RabbitMQClientImpl)client).getChannelInstance()) {
+          pendingAcks.clear();
+          lastChannelInstance = ((RabbitMQClientImpl)client).getChannelInstance();
+        }
+      }
     });
   }
 
@@ -138,17 +146,17 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     sendQueue.emptyHandler(null);
     sendQueue.resume();
   }
-  
+
   private Promise<Void> startForPromise() {
     Promise<Void> promise = Promise.promise();
     addConfirmListener(client, options, promise);
     return promise;
   }
-  
+
   protected final void addConfirmListener(RabbitMQClient client1
           , RabbitMQPublisherOptions options1
           , Promise<Void> promise
-  ) {    
+  ) {
     client1.addConfirmListener(options1.getMaxInternalQueueSize(),
             ar -> {
               if (ar.succeeded()) {
@@ -172,13 +180,13 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
   public int queueSize() {
     return sendQueue.size();
   }
-  
+
   private void handleMessageSend(MessageDetails md) {
     sendQueue.pause();
     synchronized(pendingAcks) {
       pendingAcks.add(md);
     }
-    doSend(md);    
+    doSend(md);
   }
 
   private void doSend(MessageDetails md) {
@@ -186,7 +194,7 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
       client.basicPublishWithDeliveryTag(md.exchange, md.routingKey, md.properties, md.message
           , dt -> { md.setDeliveryTag(dt); }
           , publishResult -> {
-            try {              
+            try {
               if (publishResult.succeeded()) {
                 if (md.publishHandler != null) {
                   try {
@@ -221,15 +229,9 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
       });
     }
   }
-  
+
   private void handleConfirmation(RabbitMQConfirmation rawConfirmation) {
     synchronized(pendingAcks) {
-      if (lastChannelInstance == 0) {
-        lastChannelInstance = rawConfirmation.getChannelInstance();
-      } else if (lastChannelInstance != rawConfirmation.getChannelInstance()) {
-        pendingAcks.clear();
-        lastChannelInstance = rawConfirmation.getChannelInstance();
-      }
       if (rawConfirmation.isMultiple()) {
         for (Iterator<MessageDetails> iter = pendingAcks.iterator(); iter.hasNext(); ) {
           MessageDetails md = iter.next();
@@ -255,7 +257,7 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
       }
     }
   }
-  
+
   @Override
   public void publish(String exchange, String routingKey, BasicProperties properties, Buffer body, Handler<AsyncResult<Void>> resultHandler) {
     if (!stopped) {
@@ -270,8 +272,8 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
     Promise<Void> promise = Promise.promise();
     publish(exchange, routingKey, properties, body, promise);
     return promise.future();
-  }  
-  
+  }
+
   @Override
   public RabbitMQPublisherImpl exceptionHandler(Handler<Throwable> hndlr) {
     confirmations.exceptionHandler(hndlr);
@@ -306,7 +308,7 @@ public class RabbitMQPublisherImpl implements RabbitMQPublisher, ReadStream<Rabb
   public RabbitMQPublisherImpl endHandler(Handler<Void> hndlr) {
     return this;
   }
-  
-  
-  
+
+
+
 }


### PR DESCRIPTION
Motivation:
After reconnection, the messageDetail of the first published message is put into  [pendingAcks](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java#L179). It should be processed after the acknowledgment of the first message arrives. However, pendingAcks is cleared [here](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java#L230).  This results in the first messageDetail never being processed. It will be better to clear on [connectionEstablishedCallback](https://github.com/vert-x3/vertx-rabbitmq-client/blob/7432aceb03b86d2a3cd0c626fa95650ead19122a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQPublisherImpl.java#L96).