### PR TITLE
Add SASL auth configuration support

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
 
+import com.rabbitmq.client.DefaultSaslConfig;
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.CredentialsRefreshService;
 import io.vertx.codegen.annotations.DataObject;
@@ -121,6 +122,7 @@ public class RabbitMQOptions extends NetClientOptions {
   private String connectionName;
   private CredentialsProvider credentialsProvider;
   private CredentialsRefreshService credentialsRefreshService;
+  private DefaultSaslConfig saslConfig;
 
   public RabbitMQOptions() {
     super();
@@ -154,6 +156,7 @@ public class RabbitMQOptions extends NetClientOptions {
     this.useNio = other.useNio;
     this.connectionName = other.connectionName;
     this.credentialsProvider = other.credentialsProvider;
+    this.saslConfig = other.saslConfig;
   }
 
   private void init() {
@@ -175,6 +178,7 @@ public class RabbitMQOptions extends NetClientOptions {
     this.useNio = DEFAULT_USE_NIO_SOCKETS;
     this.connectionName = DEFAULT_CONNECTION_NAME;
     this.credentialsProvider = null;
+    this.saslConfig = null;
   }
 
 
@@ -492,6 +496,22 @@ public class RabbitMQOptions extends NetClientOptions {
   public RabbitMQOptions setCredentialsRefreshService(
     CredentialsRefreshService credentialsRefreshService) {
     this.credentialsRefreshService = credentialsRefreshService;
+    return this;
+  }
+
+  /**
+   * @return The specified DefaultSaslConfiguration rabbitmq authentication mechanism
+   */
+  public DefaultSaslConfig getSaslConfig() { return saslConfig; }
+
+  /**
+   * Set the SASL mechanism for rabbitmq authentication
+   *
+   * @param saslConfig The
+   * @return a reference to this, so the API can be used fluently.
+   */
+  public RabbitMQOptions setSaslConfig(DefaultSaslConfig saslConfig) {
+    this.saslConfig = saslConfig;
     return this;
   }
 

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -23,9 +23,6 @@ import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
 
-import com.rabbitmq.client.impl.AMQImpl;
-import com.rabbitmq.client.impl.CredentialsProvider;
-import com.rabbitmq.client.impl.DefaultCredentialsRefreshService;
 import io.netty.handler.ssl.JdkSslContext;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
@@ -123,6 +120,11 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
 
     if (config.isNioEnabled()) {
       cf.useNio();
+    }
+
+    if (config.getSaslConfig() != null) {
+      // rabbitMQ client defaults to PLAIN
+      cf.setSaslConfig(config.getSaslConfig());
     }
 
     if (config.getCredentialsProvider() != null) {


### PR DESCRIPTION
Motivation:

Per https://www.rabbitmq.com/access-control.html#mechanisms 
RabbitMQ allows multiple SASL authentication mechanisms.  This change allows SASL to be configured to something other than the default of PLAIN. 
`DefaultSaslConfig.EXTERNAL` is often used when performing certificate based authentication.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
