### PR TITLE
create buffer with default encoding

### DIFF
--- a/src/main/java/examples/RabbitMQExamples.java
+++ b/src/main/java/examples/RabbitMQExamples.java
@@ -84,7 +84,7 @@ public class RabbitMQExamples {
   }
 
   public void basicPublish(RabbitMQClient client) {
-    Buffer message = Buffer.buffer("body", "Hello RabbitMQ, from Vert.x !");
+    Buffer message = Buffer.buffer("Hello RabbitMQ, from Vert.x !");
     client.basicPublish("", "my.queue", message, pubResult -> {
       if (pubResult.succeeded()) {
         System.out.println("Message published !");
@@ -95,7 +95,7 @@ public class RabbitMQExamples {
   }
 
   public void basicPublishWithConfirm(RabbitMQClient client) {
-    Buffer message = Buffer.buffer("body", "Hello RabbitMQ, from Vert.x !");
+    Buffer message = Buffer.buffer("Hello RabbitMQ, from Vert.x !");
 
     // Put the channel in confirm mode. This can be done once at init.
     client.confirmSelect(confirmResult -> {


### PR DESCRIPTION
create buffer with default encoding.

Signed-off-by: Tcheutchoua Steve <tcheutchouasteve@gmail.com>

Motivation:

Current buffer creation uses, [buffer(String string, String enc) Create a new buffer from a string and using the specified encoding.](https://vertx.io/docs/apidocs/io/vertx/core/buffer/Buffer.html#buffer-java.lang.String-) instead of [buffer(String string)Create a new buffer from a string.](https://vertx.io/docs/apidocs/io/vertx/core/buffer/Buffer.html#buffer-java.lang.String-java.lang.String-), hence passing the message as encoding.

So either, use default encoding, buffer(String) or update the current usage buffer(String, String) passing an encoding.
