### PR TITLE
Do not write url connection string in logs as password can be displayed

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -95,7 +95,6 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     List<Address> addresses = null;
     if (uri != null) {
       try {
-        log.info("Connecting to " + uri);
         cf.setUri(uri);
       } catch (Exception e) {
         throw new IllegalArgumentException("Invalid rabbitmq connection uri ", e);

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -96,6 +96,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
     if (uri != null) {
       try {
         cf.setUri(uri);
+        log.info("Connecting to " + cf.getHost());
       } catch (Exception e) {
         throw new IllegalArgumentException("Invalid rabbitmq connection uri ", e);
       }
@@ -106,6 +107,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
         ? Collections.singletonList(new Address(config.getHost(), config.getPort()))
         : config.getAddresses();
       cf.setVirtualHost(config.getVirtualHost());
+      log.info("Connecting to " + addresses);
     }
 
     cf.setConnectionTimeout(config.getConnectionTimeout());


### PR DESCRIPTION
Try to avoid to display password in logs. 

This is the case when we configure Vertx RabbitMQ Client with 
```
RabbitMQOptions config = new RabbitMQOptions();
config.setUri("amqp://${username}:${password}@${host}/${vhost}");
```

