### PR TITLE
Bump rabbitmq client library to mitigate CVE-2023-46120

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <stack.version>4.5.0-SNAPSHOT</stack.version>
-    <rabbitmq.client.version>5.16.0</rabbitmq.client.version>
+    <rabbitmq.client.version>5.20.0</rabbitmq.client.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
Motivation:

Mitigate https://github.com/advisories/GHSA-mm8h-8587-p46h

Could not find a dependabot PR 🤔
