### PR TITLE
Enable setting hostname verification algorithm for ssl context provider other than the default ""

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -579,6 +579,12 @@ public class RabbitMQOptions extends NetClientOptions {
     return this;
   }
 
+  @Override
+  public RabbitMQOptions setHostnameVerificationAlgorithm(String algorithm) {
+    super.setHostnameVerificationAlgorithm(algorithm);
+    return this;
+  }
+
   public String getConnectionName() {
     return connectionName;
   }

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -123,7 +123,7 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       SslContextProvider provider;
       try {
         SSLHelper sslHelper = new SSLHelper(SSLHelper.resolveEngineOptions(config.getSslEngineOptions(), config.isUseAlpn()));
-        SslChannelProvider scp = sslHelper.resolveSslChannelProvider(config.getSslOptions(), "", false, null, null, ((VertxInternal) vertx).createEventLoopContext())
+        SslChannelProvider scp = sslHelper.resolveSslChannelProvider(config.getSslOptions(), config.getHostnameVerificationAlgorithm(), false, null, null, ((VertxInternal) vertx).createEventLoopContext())
           .toCompletionStage()
           .toCompletableFuture()
           .get(1, TimeUnit.MINUTES);

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
@@ -38,6 +38,7 @@ public class RabbitMQClientTLSConnectTest extends RabbitMQClientTestBaseTLS {
 		RabbitMQOptions config = new RabbitMQOptions();
 		config.setUri("amqp://" + rabbitmq.getContainerIpAddress() + ":" + rabbitmq.getMappedPort(5671));
 		config.setPort(rabbitmq.getMappedPort(5671));
+    config.setHostnameVerificationAlgorithm("HTTPS");
 		return config;
 	}
 

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSMutualAuthConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSMutualAuthConnectTest.java
@@ -38,6 +38,7 @@ public class RabbitMQClientTLSMutualAuthConnectTest extends RabbitMQClientTestBa
     RabbitMQOptions config = new RabbitMQOptions();
 
     config.setUri("amqp://" + rabbitmq.getContainerIpAddress() + ":" + rabbitmq.getMappedPort(5671));
+    config.setHostnameVerificationAlgorithm("HTTPS");
     return config;
   }
 


### PR DESCRIPTION
Allow setting the hostname verification algorithm of the SslChannel created for the rabbitmq connection.