### PR TITLE
Backport #215 to 4.x

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -609,6 +609,12 @@ public class RabbitMQOptions extends NetClientOptions {
     return this;
   }
 
+  @Override
+  public RabbitMQOptions setHostnameVerificationAlgorithm(String algorithm) {
+    super.setHostnameVerificationAlgorithm(algorithm);
+    return this;
+  }
+
   public String getConnectionName() {
     return connectionName;
   }

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSConnectTest.java
@@ -38,6 +38,7 @@ public class RabbitMQClientTLSConnectTest extends RabbitMQClientTestBaseTLS {
 		RabbitMQOptions config = new RabbitMQOptions();
 		config.setUri("amqp://" + rabbitmq.getContainerIpAddress() + ":" + rabbitmq.getMappedPort(5671));
 		config.setPort(rabbitmq.getMappedPort(5671));
+    config.setHostnameVerificationAlgorithm("HTTPS");
 		return config;
 	}
 

--- a/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSMutualAuthConnectTest.java
+++ b/src/test/java/io/vertx/rabbitmq/RabbitMQClientTLSMutualAuthConnectTest.java
@@ -38,6 +38,7 @@ public class RabbitMQClientTLSMutualAuthConnectTest extends RabbitMQClientTestBa
     RabbitMQOptions config = new RabbitMQOptions();
 
     config.setUri("amqp://" + rabbitmq.getContainerIpAddress() + ":" + rabbitmq.getMappedPort(5671));
+    config.setHostnameVerificationAlgorithm("HTTPS");
     return config;
   }
 


### PR DESCRIPTION
The SSLHelper already configures the hostname verification algorithm on the SslContext.
On 4.x the default is `""`.