### PR TITLE
Pass custom ExceptionHandler to ConnectionFactory.

### DIFF
--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
-
 import com.rabbitmq.client.DefaultSaslConfig;
+import com.rabbitmq.client.ExceptionHandler;
 import com.rabbitmq.client.MetricsCollector;
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.CredentialsRefreshService;
@@ -123,6 +123,7 @@ public class RabbitMQOptions extends NetClientOptions {
   private CredentialsRefreshService credentialsRefreshService;
   private DefaultSaslConfig saslConfig;
   private MetricsCollector metricsCollector;
+  private ExceptionHandler exceptionHandler;
 
   public RabbitMQOptions() {
     super();
@@ -181,6 +182,7 @@ public class RabbitMQOptions extends NetClientOptions {
     this.credentialsProvider = null;
     this.saslConfig = null;
     this.metricsCollector = null;
+    this.exceptionHandler = null;
   }
 
   @Override
@@ -536,6 +538,22 @@ public class RabbitMQOptions extends NetClientOptions {
    */
   public RabbitMQOptions setMetricsCollector(MetricsCollector metricsCollector) {
     this.metricsCollector = metricsCollector;
+    return this;
+  }
+
+  public ExceptionHandler getExceptionHandler() {
+    return exceptionHandler;
+  }
+
+  /**
+   * Provides an exception handler for RabbitMQ connection, channel, recovery and consumer lifecycle exceptions.
+   *
+   * @implNote The value is not saved/restored when using JSON.
+   * @return a reference to this, so the API can be used fluently.
+   * @see <a href="https://www.rabbitmq.com/client-libraries/java-api-guide#unhandled-exceptions">RabbitMQ Unhandled Exceptions guide</a>
+   */
+  public RabbitMQOptions setExceptionHandler(ExceptionHandler exceptionHandler) {
+    this.exceptionHandler = exceptionHandler;
     return this;
   }
 

--- a/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
+++ b/src/main/java/io/vertx/rabbitmq/RabbitMQOptions.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.ConnectionFactory;
+
 import com.rabbitmq.client.DefaultSaslConfig;
 import com.rabbitmq.client.ExceptionHandler;
 import com.rabbitmq.client.MetricsCollector;

--- a/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
+++ b/src/main/java/io/vertx/rabbitmq/impl/RabbitMQClientImpl.java
@@ -154,6 +154,10 @@ public class RabbitMQClientImpl implements RabbitMQClient, ShutdownListener {
       cf.setMetricsCollector(config.getMetricsCollector());
     }
 
+    if (config.getExceptionHandler() != null) {
+      cf.setExceptionHandler(config.getExceptionHandler());
+    }
+
     //TODO: Support other configurations
 
     return addresses == null


### PR DESCRIPTION
Motivation: 

DefaultExceptionHandler inherits handleConnectionRecoveryException method from ForgivingExceptionHandler, which only logs message. In our case we need to take specific actions, implemented through a custom handler.

Background:

We are migrating from RabbitMQ `classic` queues towards `quorum`. So far we have been using Project Reactor RabbitMQ client for consuming messages, but since it has been abandoned and it does not support quorum queues we are going to switch to Quarkus Messaging which uses vertx-rabbitmq-client under the hood - we need however possibility to tune the RabbitMQ client as much as before.